### PR TITLE
Add BSL 1.1 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,58 @@
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+Parameters
+
+Licensor:             cyrus-is
+Licensed Work:        WhoAteMyPaycheck. The Licensed Work is (c) 2026 cyrus-is.
+Additional Use Grant: You may use the Licensed Work for personal use, including
+                      self-hosting your own private instance. You may not offer
+                      the Licensed Work as a publicly accessible hosted service
+                      to third parties without the Licensor's written permission.
+Change Date:          2030-04-17
+Change License:       MIT
+
+Notice
+
+Business Source License 1.1
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.


### PR DESCRIPTION
Adds the Business Source License 1.1 with the following parameters:

- **Licensor:** cyrus-is
- **Additional Use Grant:** Personal use and self-hosting of private instances permitted. Public hosted services require written permission from the licensor.
- **Change Date:** 2030-04-17 — converts to MIT on that date
- **Change License:** MIT

This lets the code be open and forkable for personal use while reserving the right to be the only public hosted version.