### PR TITLE
Set version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "whoatemypaycheck",
-  "version": "2.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "whoatemypaycheck",
-      "version": "2.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "whoatemypaycheck",
   "private": true,
-  "version": "2.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Updates `package.json` and `package-lock.json` from `2.0.0` → `1.0.1`.
- The `2.0.0` value was an auto-enumeration carried over when this repo was migrated from a prior repo. The actual released version on this repo is `v1.0.0`, so the next patch is `1.0.1`.

## Test plan
- [x] Diff is version-only — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)