### PR TITLE
chore: add .mailmap to canonicalize git author display

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,12 @@
+# .mailmap — canonicalize git author display across machines.
+# See: https://git-scm.com/docs/gitmailmap
+#
+# Format: <canonical-name> <canonical-email> <commit-name> <commit-email>
+# GitHub and Swift Package Index both honor this for contributor lists.
+# Non-destructive: rewrites display only, not git history.
+
+Cyrus Gray <cyrus@cyrus.is>  Cyrus <104619940+cyrus-is@users.noreply.github.com>
+Cyrus Gray <cyrus@cyrus.is>  Cyrus-is <cgray@msn.com>
+Cyrus Gray <cyrus@cyrus.is>  Cyrus-is <cyrus@cyrus.is>
+Cyrus Gray <cyrus@cyrus.is>  clawrus <cgray@msn.com>
+Cyrus Gray <cyrus@cyrus.is>  clawrus <clawrus@users.noreply.github.com>


### PR DESCRIPTION
## Summary

Adds `.mailmap` at the repo root to canonicalize git author display across machines. Same file lands in all of my repos (HQ, finite-extract, finite-research, hiveroute, ironclad-skies, pre-flight, scrutineer, spending-sankey, ti, WhoAteMyPaycheck, cyrus.is, 1way; pocket-extrovert deferred until its WIP branch closes).

Non-destructive — rewrites display only, not git history. GitHub + Swift Package Index both honor `.mailmap` for contributor lists, so the page collapses from "Cyrus / Cyrus Gray / Cyrus-is / clawrus" + a phantom "1 other" down to one human contributor.

## Test plan

- [ ] CI green
- [ ] After merge: `git log --use-mailmap | head` shows a single canonical author for older commits