### PR TITLE
fix: align key-storage trust copy with actual apiKey.ts behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ What lives where:
 - Budget → `localStorage` (survives page refresh)
 - Categorization cache → `sessionStorage` (keyed by description+amount+type+mode)
 - Tax cache → `sessionStorage` (keyed by description+amount)
-- API key → `sessionStorage`
+- API key → `sessionStorage` by default; `localStorage` when "Remember my key" is checked
 - Hidden categories → `localStorage`
 - How-it-works seen flag → `localStorage`
 
@@ -114,7 +114,7 @@ Lenses live in `src/lib/lenses/`. Each lens remaps category strings for the Sank
 ## Key Decisions
 
 1. **Client-side only.** No backend, no database. The only network call is the Claude API for categorization. The Anthropic SDK is lazy-loaded — it doesn't ship in the initial bundle.
-2. **Privacy-first.** Bank data never touches a server we control. The Claude API call sends merchant descriptions, amounts, and debit/credit type only — no account numbers, balances, or PII. API key is in sessionStorage, never localStorage.
+2. **Privacy-first.** Bank data never touches a server we control. The Claude API call sends merchant descriptions, amounts, and debit/credit type only — no account numbers, balances, or PII. API key is in sessionStorage by default; localStorage only when the user opts in via "Remember my key".
 3. **CSV-first, not bank-API.** Users export CSVs manually. Avoids Plaid/credentials complexity. Every bank supports CSV export.
 4. **Budget from reality.** The budget generator uses actual spending patterns (median monthly for discretionary, last-observed for fixed recurring, CV thresholds to classify). No prescriptive targets.
 5. **BSL over fully permissive.** Open for personal use and self-hosting; public competing services require permission. Converts to MIT in 2030.
@@ -164,7 +164,7 @@ Lenses live in `src/lib/lenses/`. Each lens remaps category strings for the Sank
 ### Security
 - Never log or persist raw bank data (raw CSV rows, account numbers, balances)
 - `console.debug` calls in `categorize.ts` are DEV-only (`import.meta.env.DEV` guard)
-- Claude API key: sessionStorage only, never localStorage
+- Claude API key: sessionStorage by default; localStorage only via the explicit "Remember my key" opt-in (`src/lib/apiKey.ts`)
 - CSP is set in `index.html` — don't weaken it
 - CSV exports sanitize formula injection prefixes (`=`, `+`, `-`, `@`)
 - No telemetry, no analytics, no tracking

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The tax lens flags transactions that could fit multiple IRS categories for your 
 - All CSV parsing and processing runs locally in the page
 - The only outbound network call is to the Claude API for transaction categorization
 - That call sends merchant names and amounts only — **account numbers are never sent**
-- Your Claude API key is stored in `sessionStorage` (cleared when you close the tab, never sent anywhere except Anthropic's API)
+- Your Claude API key is stored only in your browser — in `sessionStorage` by default (cleared when you close the tab), or in `localStorage` if you check "Remember my key" (kept on this device until you clear it). It is never sent anywhere except Anthropic's API
 - No analytics, no telemetry, no server of any kind
 
 This is the core design constraint, not an afterthought. The reason the app exists is that connecting real bank credentials to a third party is a significant trust ask. CSV export sidesteps that entirely.

--- a/src/components/ApiKeyEntry.test.tsx
+++ b/src/components/ApiKeyEntry.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ApiKeyEntry } from './ApiKeyEntry'
+import { storeApiKey } from '../lib/apiKey'
+
+// Node's experimental webstorage shadows jsdom's localStorage with a
+// non-functional stub (no --localstorage-file), so install a working
+// in-memory Storage for these tests.
+function createMemoryStorage(): Storage {
+  let store: Record<string, string> = {}
+  return {
+    get length() {
+      return Object.keys(store).length
+    },
+    clear: () => {
+      store = {}
+    },
+    getItem: (key: string) => store[key] ?? null,
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+  }
+}
+
+describe('ApiKeyEntry', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createMemoryStorage())
+    vi.stubGlobal('sessionStorage', createMemoryStorage())
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows the key-status pill without a remembered disclosure for a session-only key', () => {
+    storeApiKey('sk-ant-test', false)
+    render(<ApiKeyEntry onKey={() => {}} hasKey={true} />)
+    expect(screen.getByText('Claude API key set')).toBeInTheDocument()
+    expect(screen.queryByText('remembered on this device')).not.toBeInTheDocument()
+  })
+
+  it('discloses a remembered key next to the key-status pill', () => {
+    storeApiKey('sk-ant-test', true)
+    render(<ApiKeyEntry onKey={() => {}} hasKey={true} />)
+    expect(screen.getByText('Claude API key set')).toBeInTheDocument()
+    expect(screen.getByText('remembered on this device')).toBeInTheDocument()
+  })
+
+  it('shows the disclosure after submitting with "Remember my key" checked', () => {
+    const onKey = vi.fn()
+    const { rerender } = render(<ApiKeyEntry onKey={onKey} hasKey={false} />)
+
+    fireEvent.change(screen.getByLabelText(/Claude API key/), {
+      target: { value: 'sk-ant-test' },
+    })
+    fireEvent.click(screen.getByRole('checkbox'))
+    fireEvent.click(screen.getByText('Save'))
+    expect(onKey).toHaveBeenCalledWith('sk-ant-test')
+
+    rerender(<ApiKeyEntry onKey={onKey} hasKey={true} />)
+    expect(screen.getByText('remembered on this device')).toBeInTheDocument()
+  })
+
+  it('does not show the disclosure after submitting with "Remember my key" unchecked', () => {
+    const onKey = vi.fn()
+    const { rerender } = render(<ApiKeyEntry onKey={onKey} hasKey={false} />)
+
+    fireEvent.change(screen.getByLabelText(/Claude API key/), {
+      target: { value: 'sk-ant-test' },
+    })
+    fireEvent.click(screen.getByText('Save'))
+
+    rerender(<ApiKeyEntry onKey={onKey} hasKey={true} />)
+    expect(screen.getByText('Claude API key set')).toBeInTheDocument()
+    expect(screen.queryByText('remembered on this device')).not.toBeInTheDocument()
+  })
+
+  it('clears the remembered key when Clear is clicked', () => {
+    storeApiKey('sk-ant-test', true)
+    const onKey = vi.fn()
+    render(<ApiKeyEntry onKey={onKey} hasKey={true} />)
+
+    fireEvent.click(screen.getByText('Clear'))
+    expect(onKey).toHaveBeenCalledWith('')
+    expect(localStorage.getItem('claude_api_key_saved')).toBeNull()
+    expect(localStorage.getItem('claude_api_key_remember')).toBeNull()
+  })
+
+  it('discloses localStorage persistence on the "Remember my key" label', () => {
+    render(<ApiKeyEntry onKey={() => {}} hasKey={false} />)
+    expect(
+      screen.getByText(/kept in this browser's localStorage until you clear it/),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/ApiKeyEntry.tsx
+++ b/src/components/ApiKeyEntry.tsx
@@ -31,6 +31,14 @@ export function ApiKeyEntry({ onKey, hasKey }: ApiKeyEntryProps) {
       <div className="api-key-status">
         <span className="api-key-status__dot" />
         <span className="api-key-status__text">Claude API key set</span>
+        {isKeyRemembered() && (
+          <span
+            className="api-key-status__remembered"
+            title="Stored in this browser's localStorage until you clear it"
+          >
+            remembered on this device
+          </span>
+        )}
         <button className="api-key-status__clear" onClick={handleClear}>
           Clear
         </button>
@@ -75,7 +83,10 @@ export function ApiKeyEntry({ onKey, hasKey }: ApiKeyEntryProps) {
           checked={remember}
           onChange={(e) => setRemember(e.target.checked)}
         />
-        Remember my key
+        Remember my key{' '}
+        <span className="api-key-form__hint">
+          (kept in this browser&apos;s localStorage until you clear it)
+        </span>
       </label>
     </form>
   )

--- a/src/components/HowItWorksModal.tsx
+++ b/src/components/HowItWorksModal.tsx
@@ -109,7 +109,7 @@ export function HowItWorksModal({ open, onClose }: HowItWorksModalProps) {
             <li>Go to <strong>console.anthropic.com</strong> and create a free account.</li>
             <li>In the sidebar, click <strong>API Keys</strong> → <strong>Create Key</strong>.</li>
             <li>Copy the key (it starts with <code>sk-ant-</code>) and paste it into the API key field at the top of this page.</li>
-            <li>The key is stored only in your browser's session memory — it disappears when you close the tab.</li>
+            <li>The key is stored only in your browser: in session memory that disappears when you close the tab, or — if you check <strong>Remember my key</strong> — in this browser's local storage until you clear it.</li>
             <li>Save it somewhere you can find it later.</li>
           </ol>
           <p className="hiw-note">

--- a/src/lib/apiKey.test.ts
+++ b/src/lib/apiKey.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
+import { getStoredApiKey, storeApiKey, isKeyRemembered } from './apiKey'
+
+// Node's experimental webstorage shadows jsdom's localStorage with a
+// non-functional stub (no --localstorage-file), so install a working
+// in-memory Storage for these tests.
+function createMemoryStorage(): Storage {
+  let store: Record<string, string> = {}
+  return {
+    get length() {
+      return Object.keys(store).length
+    },
+    clear: () => {
+      store = {}
+    },
+    getItem: (key: string) => store[key] ?? null,
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+  }
+}
+
+describe('apiKey', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createMemoryStorage())
+    vi.stubGlobal('sessionStorage', createMemoryStorage())
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('stores the key in sessionStorage only when remember is off', () => {
+    storeApiKey('sk-ant-session', false)
+    expect(sessionStorage.getItem('claude_api_key')).toBe('sk-ant-session')
+    expect(localStorage.getItem('claude_api_key_saved')).toBeNull()
+    expect(isKeyRemembered()).toBe(false)
+    expect(getStoredApiKey()).toBe('sk-ant-session')
+  })
+
+  it('stores the key in localStorage when remember is on', () => {
+    storeApiKey('sk-ant-local', true)
+    expect(localStorage.getItem('claude_api_key_saved')).toBe('sk-ant-local')
+    expect(sessionStorage.getItem('claude_api_key')).toBeNull()
+    expect(isKeyRemembered()).toBe(true)
+    expect(getStoredApiKey()).toBe('sk-ant-local')
+  })
+
+  it('moves a remembered key out of localStorage when re-saved without remember', () => {
+    storeApiKey('sk-ant-local', true)
+    storeApiKey('sk-ant-local', false)
+    expect(localStorage.getItem('claude_api_key_saved')).toBeNull()
+    expect(localStorage.getItem('claude_api_key_remember')).toBeNull()
+    expect(sessionStorage.getItem('claude_api_key')).toBe('sk-ant-local')
+    expect(isKeyRemembered()).toBe(false)
+  })
+
+  it('clears the key from both storages when given an empty key', () => {
+    storeApiKey('sk-ant-local', true)
+    storeApiKey('', false)
+    expect(localStorage.getItem('claude_api_key_saved')).toBeNull()
+    expect(localStorage.getItem('claude_api_key_remember')).toBeNull()
+    expect(sessionStorage.getItem('claude_api_key')).toBeNull()
+    expect(getStoredApiKey()).toBe('')
+    expect(isKeyRemembered()).toBe(false)
+  })
+})

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -410,6 +410,14 @@ body {
   padding: 2px 8px;
 }
 
+.api-key-status__remembered {
+  border: 1px solid #4a5568;
+  border-radius: 999px;
+  color: #a0aec0;
+  font-size: 0.75rem;
+  padding: 1px 8px;
+}
+
 /* File summary */
 .file-summary {
   font-size: 0.875rem;


### PR DESCRIPTION
## Spec source

`docs/product-review-fable.md` §5 **PR-1** (motivated by the trust-copy drift analysis in §1.3 #8): copy in `HowItWorksModal.tsx`, `README.md`, and `CLAUDE.md` promised the API key lives in sessionStorage only, but `apiKey.ts` stores it in **localStorage** when "Remember my key" is checked. The control is live code (wired through `storeApiKey`), so per the spec the copy is fixed to match the code — key-storage behavior is unchanged.

## Changes

- **`HowItWorksModal.tsx`** — step 4 now describes both modes: session memory by default, this browser's local storage when "Remember my key" is checked.
- **`README.md`** privacy section — same correction for the `sessionStorage` bullet.
- **`CLAUDE.md`** — all three claims updated ("What lives where", Key Decisions #2, Security standards).
- **`ApiKeyEntry.tsx`** — a remembered key is now disclosed next to the key-status pill ("remembered on this device", with a localStorage tooltip); the "Remember my key" checkbox gains a persistence hint.
- **`global.css`** — one badge class for the disclosure, reusing existing color values only.
- **Tests** — new `ApiKeyEntry.test.tsx` (6 tests: disclosure shown/hidden for remembered vs session keys, after submit with/without remember, cleared on Clear, checkbox hint) and new `apiKey.test.ts` pinning the storage behavior the copy now describes. Both install an in-memory `Storage` stub because Node ≥22's experimental webstorage shadows jsdom's `localStorage` with a non-functional stub when no `--localstorage-file` is set (observed locally on Node 25.6.1).

## Acceptance criteria

- [x] **Every user-facing claim about key storage matches the code** — HowItWorksModal, README privacy section, CLAUDE.md, and the ApiKeyEntry checkbox label all now describe sessionStorage-by-default / localStorage-on-opt-in, matching `apiKey.ts`. Swept the repo for residual "sessionStorage only / session memory / close the tab" claims; none remain.
- [x] **Checked "remember" state visibly disclosed next to the key-status pill** — `isKeyRemembered()` renders a "remembered on this device" badge beside the pill.
- [x] **Component test covering the disclosure rendering** — `src/components/ApiKeyEntry.test.tsx`.

`npm run lint`, `npm run build`, and `npm test` (374 tests, 19 files) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)