### PR TITLE
feat(classify): offline-first categorization + partial Sankey (PR-3)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -104,6 +104,37 @@ describe('App — offline-first categorization', () => {
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
+  it('still renders a Sankey via the Uncategorized sink when a CSV has zero offline merchant hits', async () => {
+    const rows = [
+      { date: '01/05/2024', description: 'ZZQX UNKNOWN MERCHANT 991', amount: '42.10' },
+      { date: '01/12/2024', description: 'PLRVX MERCHANT ID 4471', amount: '18.75' },
+      { date: '01/20/2024', description: 'QWKJH RANDOM VENDOR 205', amount: '63.40' },
+    ]
+    // Self-validating: confirm the fixture genuinely produces zero offline hits, so this test
+    // actually exercises the zero-offline-hit path rather than silently passing on a fluke.
+    for (const row of rows) {
+      expect(classifyByMerchant(row.description, 'debit')).toBeNull()
+    }
+
+    const csv = ['Date,Description,Amount', ...rows.map((r) => `${r.date},${r.description},${r.amount}`)].join('\n')
+    const file = new File([csv], 'synthetic-unknown.csv', { type: 'text/csv' })
+
+    const { container } = render(<App />)
+    await dropFile(container, file)
+
+    await waitFor(() => {
+      expect(container.querySelector('svg')).toBeInTheDocument()
+    })
+
+    // TransactionTable (not RawTable) renders even though hasCategorized is false
+    expect(screen.getByText('Transactions')).toBeInTheDocument()
+
+    // 0% offline coverage — every transaction routes through the Uncategorized sink
+    expect(screen.getByText(/0% categorized on-device\. Add a Claude API key/)).toBeInTheDocument()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
   it('shows "Categorize remaining N with Claude" only when a key is present and a remainder exists', async () => {
     storeApiKey('sk-ant-test-key', false)
     const { container } = render(<App />)

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Component test for offline-first categorization + partial Sankey rendering
+ * (docs/classification-improvement-fable.md §2.C, docs/product-review-fable.md §5 PR-2).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import Papa from 'papaparse'
+import { App } from './App'
+import { detectFormat, parseTransactions } from './lib/parser'
+import { detectTransfers } from './lib/transfers'
+import { classifyByMerchant } from './lib/merchantLookup'
+import { storeApiKey } from './lib/apiKey'
+
+// Node's experimental webstorage shadows jsdom's localStorage with a non-functional stub
+// (no --localstorage-file), so install a working in-memory Storage for these tests —
+// same pattern as ApiKeyEntry.test.tsx.
+function createMemoryStorage(): Storage {
+  let store: Record<string, string> = {}
+  return {
+    get length() {
+      return Object.keys(store).length
+    },
+    clear: () => {
+      store = {}
+    },
+    getItem: (key: string) => store[key] ?? null,
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+  }
+}
+
+function loadSampleFile(filename: string): File {
+  const content = readFileSync(resolve(__dirname, '../sample-data', filename), 'utf8')
+  return new File([content], filename, { type: 'text/csv' })
+}
+
+/** Mirrors useCategorization's handleFiles offline pipeline to compute an independent
+ *  expected on-device coverage percentage for the fixture, without touching the DOM. */
+function expectedOfflineCoveragePercent(filename: string): number {
+  const csv = readFileSync(resolve(__dirname, '../sample-data', filename), 'utf8')
+  const result = Papa.parse<Record<string, string>>(csv, { header: true, skipEmptyLines: true })
+  const mapping = detectFormat(result.meta.fields ?? [], result.data)
+  const { transactions } = parseTransactions(filename, result.data, mapping)
+
+  const transferIds = detectTransfers(transactions)
+  const nonTransfer = transactions.filter((tx) => !transferIds.has(tx.id))
+  const categorized = nonTransfer.filter((tx) => classifyByMerchant(tx.description, tx.type) !== null)
+
+  return Math.round((categorized.length / nonTransfer.length) * 100)
+}
+
+async function dropFile(container: HTMLElement, file: File) {
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement
+  Object.defineProperty(input, 'files', { value: [file], configurable: true })
+  fireEvent.change(input)
+}
+
+describe('App — offline-first categorization', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createMemoryStorage())
+    vi.stubGlobal('sessionStorage', createMemoryStorage())
+    localStorage.setItem('whoatemypaycheck:how-it-works-seen', '1')
+    fetchSpy = vi.fn(() => Promise.reject(new Error('unexpected network request in test')))
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('categorizes ≥80% of transactions on-device with no API key, renders a Sankey, and makes zero network requests', async () => {
+    const expectedPercent = expectedOfflineCoveragePercent('bofa-credit-card.csv')
+    expect(expectedPercent).toBeGreaterThanOrEqual(80)
+
+    const { container } = render(<App />)
+
+    await dropFile(container, loadSampleFile('bofa-credit-card.csv'))
+
+    // Sankey rendered from offline-only categorization (no API key was ever set)
+    await waitFor(() => {
+      expect(container.querySelector('svg')).toBeInTheDocument()
+    })
+
+    // TransactionTable (not RawTable) is showing, confirming hasCategorized flipped true
+    expect(screen.getByText('Transactions')).toBeInTheDocument()
+
+    // Coverage banner shows the on-device percentage and prompts for a key
+    const banner = screen.getByText(/% categorized on-device\. Add a Claude API key/)
+    expect(banner).toHaveTextContent(`${expectedPercent}% categorized on-device.`)
+
+    // No API key was ever provided, so the Claude button must not render
+    expect(screen.queryByText(/Categorize remaining/)).not.toBeInTheDocument()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('shows "Categorize remaining N with Claude" only when a key is present and a remainder exists', async () => {
+    storeApiKey('sk-ant-test-key', false)
+    const { container } = render(<App />)
+
+    await dropFile(container, loadSampleFile('bofa-credit-card.csv'))
+
+    await waitFor(() => {
+      expect(container.querySelector('svg')).toBeInTheDocument()
+    })
+
+    const button = await screen.findByRole('button', { name: /Categorize remaining \d+ with Claude/ })
+    expect(button).toBeInTheDocument()
+
+    // The on-device coverage banner is for the key-free path only — once a key is present
+    // the button (with its own remaining-count hint) replaces it.
+    expect(screen.queryByText(/% categorized on-device/)).not.toBeInTheDocument()
+
+    // Dropping files and rendering offline-only results makes no network calls —
+    // categorization only fires on an explicit click of the button above.
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { detectAnomalies } from './lib/anomaly'
 import { CategoryVisibilityToggle } from './components/CategoryVisibilityToggle'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { EXPENSE_CATEGORIES } from './lib/types'
+import { displayCategory, isUnclassifiedDefault } from './lib/classification'
 
 export function App() {
   const [apiKey, setApiKey] = useState<string>(() => getStoredApiKey())
@@ -76,28 +77,27 @@ export function App() {
     )
   }, [cat.allTransactions, dateRange])
 
-  // Categories present in the current filtered view (for the visibility toggle)
+  // Categories present in the current filtered view (for the visibility toggle) — uses the
+  // same displayCategory relabel as the Sankey and TransactionTable so "Uncategorized" spend
+  // is listed (and hideable) as its own entry instead of hiding under "Other".
   const spendingCategories = useMemo(() => {
-    if (!cat.hasCategorized || activeLens !== 'spending') return []
+    if (cat.allTransactions.length === 0 || activeLens !== 'spending') return []
     const totals = new Map<string, number>()
     for (const tx of filteredTransactions) {
-      const c = cat.overrides[tx.id] ?? tx.category
-      if (!EXPENSE_CATEGORIES.has(c)) continue
+      const c = displayCategory(tx, cat.overrides)
+      if (c !== 'Uncategorized' && !EXPENSE_CATEGORIES.has(c)) continue
       if (tx.type !== 'debit') continue
       totals.set(c, (totals.get(c) ?? 0) + tx.amount)
     }
     return [...totals.entries()]
       .map(([name, amount]) => ({ name, amount }))
       .sort((a, b) => b.amount - a.amount)
-  }, [cat.hasCategorized, activeLens, filteredTransactions, cat.overrides])
+  }, [cat.allTransactions.length, activeLens, filteredTransactions, cat.overrides])
 
   // Transactions passed to Sankey — excludes hidden categories (spending lens only)
   const sankeyTransactions = useMemo(() => {
     if (hiddenCategories.size === 0 || activeLens !== 'spending') return filteredTransactions
-    return filteredTransactions.filter((tx) => {
-      const c = cat.overrides[tx.id] ?? tx.category
-      return !hiddenCategories.has(c)
-    })
+    return filteredTransactions.filter((tx) => !hiddenCategories.has(displayCategory(tx, cat.overrides)))
   }, [filteredTransactions, hiddenCategories, activeLens, cat.overrides])
 
   const budget = useBudget(
@@ -145,6 +145,10 @@ export function App() {
     for (const tx of filteredTransactions) {
       const spendingCategory = cat.overrides[tx.id] ?? tx.category
       if (spendingCategory === 'Transfer') continue
+      // Leave still-unclassified transactions unmapped so buildSankeyData's own
+      // isUnclassifiedDefault check routes them to the Uncategorized sink instead of
+      // Other silently inflating the discretionary bucket.
+      if (cat.overrides[tx.id] === undefined && isUnclassifiedDefault(tx)) continue
       result[tx.id] = mapToEssentialsBucket(spendingCategory)
     }
     return result
@@ -156,7 +160,9 @@ export function App() {
   )
 
   const sankeyData = useMemo(() => {
-    if (!cat.hasCategorized) return null
+    // Gated on data existing, not on any offline hit — the Uncategorized sink node absorbs
+    // whatever the offline layers didn't catch, so even a 0%-offline-hit CSV still renders.
+    if (cat.allTransactions.length === 0) return null
     if (activeLens === 'essentials') {
       return buildSankeyData(sankeyTransactions, essentialsOverrides, mergeThreshold, essentialsColors)
     }
@@ -182,7 +188,7 @@ export function App() {
       cat.categorizationMode,
     )
   }, [
-    cat.hasCategorized, activeLens, sankeyTransactions, cat.overrides,
+    cat.allTransactions.length, activeLens, sankeyTransactions, cat.overrides,
     essentialsOverrides, essentialsColors, tax.taxResults, taxCategoryMap,
     tax.taxColors, mergeThreshold, cat.categorizationMode,
   ])
@@ -334,15 +340,20 @@ export function App() {
           </div>
         )}
 
-        {cat.hasCategorized && (
+        {cat.allTransactions.length > 0 && (
           <LensSwitcher
             active={activeLens}
             onChange={handleLensChange}
-            taxReady={cat.hasCategorized}
+            taxReady={cat.hasCategorized && !!apiKey}
+            taxDisabledReason={
+              !apiKey
+                ? 'Add a Claude API key to unlock the Tax lens'
+                : 'Categorize at least one transaction first to unlock the Tax lens'
+            }
           />
         )}
 
-        {cat.hasCategorized && minDate && (
+        {cat.allTransactions.length > 0 && minDate && (
           <DateFilter
             range={dateRange}
             minDate={minDate}
@@ -449,7 +460,7 @@ export function App() {
           />
         </ErrorBoundary>
 
-        {cat.hasCategorized ? (
+        {cat.allTransactions.length > 0 ? (
           <TransactionTable
             transactions={filteredTransactions}
             overrides={cat.overrides}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -277,7 +277,9 @@ export function App() {
         {cat.showCategorizeBtn && (
           <div className="categorize-wrap">
             <button className="categorize-btn" onClick={cat.handleCategorize}>
-              {cat.hasCategorized ? 'Re-categorize with Claude' : 'Categorize with Claude'}
+              {cat.modeChanged
+                ? 'Re-categorize with Claude'
+                : `Categorize remaining ${cat.uncategorizedCount} with Claude`}
             </button>
             <p className="categorize-hint">
               Sends merchant names and amounts to Claude API to classify{' '}
@@ -295,10 +297,10 @@ export function App() {
           </div>
         )}
 
-        {!apiKey && cat.uncategorizedCount > 0 && (
+        {!apiKey && cat.allTransactions.length > 0 && cat.uncategorizedCount > 0 && (
           <div className="warn-banner">
-            No API key set. Add your Claude API key above to categorize transactions and see the
-            Sankey diagram.
+            {cat.percentCategorized}% categorized on-device. Add a Claude API key to categorize
+            the rest.
           </div>
         )}
 

--- a/src/components/LensSwitcher.tsx
+++ b/src/components/LensSwitcher.tsx
@@ -4,6 +4,8 @@ interface LensSwitcherProps {
   active: LensId
   onChange: (lens: LensId) => void
   taxReady: boolean
+  /** Tooltip shown on the disabled Tax lens button — explains what's missing (API key vs. no categorized data yet) */
+  taxDisabledReason?: string
 }
 
 const LENSES: { id: LensId; label: string }[] = [
@@ -12,7 +14,7 @@ const LENSES: { id: LensId; label: string }[] = [
   { id: 'essentials', label: 'Essentials' },
 ]
 
-export function LensSwitcher({ active, onChange, taxReady }: LensSwitcherProps) {
+export function LensSwitcher({ active, onChange, taxReady, taxDisabledReason }: LensSwitcherProps) {
   return (
     <div className="lens-switcher" role="group" aria-label="View lens">
       {LENSES.map(({ id, label }) => {
@@ -25,7 +27,7 @@ export function LensSwitcher({ active, onChange, taxReady }: LensSwitcherProps) 
             onClick={() => !disabled && onChange(id)}
             aria-pressed={active === id}
             disabled={disabled}
-            title={disabled ? 'Run "Categorize with Claude" first to unlock the Tax lens' : undefined}
+            title={disabled ? (taxDisabledReason ?? 'Run "Categorize with Claude" first to unlock the Tax lens') : undefined}
           >
             {label}
           </button>

--- a/src/components/TransactionTable.tsx
+++ b/src/components/TransactionTable.tsx
@@ -1,5 +1,6 @@
 import type { Transaction } from '../lib/types'
 import { CATEGORIES } from '../lib/types'
+import { isUnclassifiedDefault } from '../lib/classification'
 
 interface TransactionTableProps {
   transactions: Transaction[]
@@ -66,7 +67,13 @@ export function TransactionTable({ transactions, overrides, onOverride }: Transa
                         <option key={c} value={c}>{c}</option>
                       ))}
                     </select>
-                    {tx.subcategory && <span className="tx-subcategory"> · {tx.subcategory}</span>}
+                    {tx.subcategory ? (
+                      <span className="tx-subcategory"> · {tx.subcategory}</span>
+                    ) : (
+                      !overrides[tx.id] && isUnclassifiedDefault(tx) && (
+                        <span className="tx-subcategory"> · Uncategorized</span>
+                      )
+                    )}
                     {isCorrected && (
                       <span className="tx-report-wrap">
                         <a

--- a/src/hooks/useBudget.ts
+++ b/src/hooks/useBudget.ts
@@ -5,6 +5,7 @@ import type { DateRange } from '../components/DateFilter'
 import { generateBudget, compareBudgetToActual, countMonths } from '../lib/budget'
 import type { BudgetComparisonResult } from '../lib/budget-types'
 import { saveBudget, loadBudget, clearBudget } from '../lib/budgetStorage'
+import { isUnclassifiedDefault } from '../lib/classification'
 
 function toDateStr(d: Date): string {
   return d.toISOString().substring(0, 10)
@@ -62,7 +63,11 @@ export function useBudget(
     const sourceRange = minDate && maxDate
       ? { start: minDate, end: maxDate }
       : { start: toDateStr(new Date()), end: toDateStr(new Date()) }
-    const generated = generateBudget(allTransactions, sourceRange)
+    // Exclude still-unclassified debit spend so it doesn't silently book into the "Other"
+    // expense line — income is left untouched since it's already correctly bucketed as
+    // Income regardless of subcategory detail.
+    const classified = allTransactions.filter((tx) => tx.type !== 'debit' || !isUnclassifiedDefault(tx))
+    const generated = generateBudget(classified, sourceRange)
     setBudget(generated)
     saveBudget(generated)
   }, [hasCategorized, allTransactions, minDate, maxDate])

--- a/src/hooks/useCategorization.test.ts
+++ b/src/hooks/useCategorization.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Offline-first classification tests for useCategorization.handleFiles
+ * (docs/classification-improvement-fable.md §2.C, docs/product-review-fable.md §5 PR-2).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { useCategorization } from './useCategorization'
+
+function loadSampleFile(filename: string): File {
+  const content = readFileSync(resolve(__dirname, '../../sample-data', filename), 'utf8')
+  return new File([content], filename, { type: 'text/csv' })
+}
+
+describe('useCategorization — offline-first classification', () => {
+  it('classifies known merchants via classifyByMerchant in handleFiles with no API key', async () => {
+    const { result } = renderHook(() => useCategorization(''))
+
+    await act(async () => {
+      await result.current.handleFiles([loadSampleFile('bofa-credit-card.csv')])
+    })
+
+    expect(result.current.allTransactions.length).toBeGreaterThan(0)
+    expect(result.current.hasCategorized).toBe(true)
+    // bofa-credit-card.csv has a known offline miss (AMAZON MKTPLACE PMTS variant) — partial, not full, coverage
+    expect(result.current.uncategorizedCount).toBeGreaterThan(0)
+    expect(result.current.percentCategorized).toBeGreaterThanOrEqual(80)
+    expect(result.current.percentCategorized).toBeLessThan(100)
+    // No API key — the Claude button must stay hidden regardless of the remainder
+    expect(result.current.showCategorizeBtn).toBe(false)
+  })
+
+  it('gates the Claude button on both a present API key and a nonzero remainder', async () => {
+    const { result } = renderHook(() => useCategorization('sk-ant-test-key'))
+
+    await act(async () => {
+      await result.current.handleFiles([loadSampleFile('bofa-credit-card.csv')])
+    })
+
+    expect(result.current.uncategorizedCount).toBeGreaterThan(0)
+    expect(result.current.showCategorizeBtn).toBe(true)
+  })
+
+  it('does not overwrite transactions already classified offline when more files are added', async () => {
+    const { result } = renderHook(() => useCategorization(''))
+
+    await act(async () => {
+      await result.current.handleFiles([loadSampleFile('bofa-credit-card.csv')])
+    })
+
+    const classified = result.current.allTransactions.find((tx) => tx.subcategory !== '')
+    expect(classified).toBeDefined()
+    const before = { category: classified!.category, subcategory: classified!.subcategory }
+
+    await act(async () => {
+      await result.current.handleFiles([loadSampleFile('amex-gold.csv')])
+    })
+
+    expect(result.current.files.length).toBe(2)
+    const after = result.current.allTransactions.find((tx) => tx.id === classified!.id)
+    expect(after?.category).toBe(before.category)
+    expect(after?.subcategory).toBe(before.subcategory)
+  })
+
+  it('never touches the network while classifying offline', async () => {
+    const fetchSpy = vi.fn(() => Promise.reject(new Error('unexpected network request in test')))
+    vi.stubGlobal('fetch', fetchSpy)
+    try {
+      const { result } = renderHook(() => useCategorization(''))
+      await act(async () => {
+        await result.current.handleFiles([loadSampleFile('bofa-credit-card.csv')])
+      })
+      expect(result.current.allTransactions.length).toBeGreaterThan(0)
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/src/hooks/useCategorization.ts
+++ b/src/hooks/useCategorization.ts
@@ -4,6 +4,7 @@ import type { CategorizationMode } from '../components/CategorizationModeSelecto
 import { readCsvFile } from '../lib/readCsv'
 import { detectFormat, parseTransactions } from '../lib/parser'
 import { detectTransfers } from '../lib/transfers'
+import { classifyByMerchant } from '../lib/merchantLookup'
 
 let fileCounter = 0
 
@@ -24,6 +25,7 @@ export interface CategorizationState {
   lastCategorizedMode: CategorizationMode | null
   modeChanged: boolean
   uncategorizedCount: number
+  percentCategorized: number
   showCategorizeBtn: boolean
   setAppState: (s: AppState) => void
   abortRef: React.MutableRefObject<AbortController | null>
@@ -58,9 +60,15 @@ export function useCategorization(apiKey: string): CategorizationState {
   const modeChanged =
     hasCategorized && lastCategorizedMode !== null && lastCategorizedMode !== categorizationMode
 
+  const nonTransferCount = allTransactions.filter((tx) => tx.category !== 'Transfer').length
+
   const uncategorizedCount = modeChanged
-    ? allTransactions.filter((tx) => tx.category !== 'Transfer').length
+    ? nonTransferCount
     : allTransactions.filter((tx) => tx.subcategory === '' && tx.category !== 'Transfer').length
+
+  const percentCategorized = nonTransferCount > 0
+    ? Math.round(((nonTransferCount - uncategorizedCount) / nonTransferCount) * 100)
+    : 0
 
   const showCategorizeBtn =
     (uncategorizedCount > 0 || modeChanged) && !!apiKey && appState !== 'categorizing'
@@ -106,13 +114,18 @@ export function useCategorization(apiKey: string): CategorizationState {
 
         const allTx = next.flatMap((f) => f.transactions)
         const transferIds = detectTransfers(allTx)
-        if (transferIds.size === 0) return next
 
+        // Free, key-free offline layers — transfer detection above, and merchant lookup
+        // here — run unconditionally so a Sankey can render before any API key exists
+        // (docs/classification-improvement-fable.md §2.C, docs/product-review-fable.md §5 PR-2).
         return next.map((file) => ({
           ...file,
-          transactions: file.transactions.map((tx) =>
-            transferIds.has(tx.id) ? { ...tx, category: 'Transfer' } : tx,
-          ),
+          transactions: file.transactions.map((tx) => {
+            if (transferIds.has(tx.id)) return { ...tx, category: 'Transfer' }
+            if (tx.category === 'Transfer' || tx.subcategory !== '') return tx
+            const match = classifyByMerchant(tx.description, tx.type)
+            return match ? { ...tx, category: match.category, subcategory: match.subcategory } : tx
+          }),
         }))
       })
     } catch (e) {
@@ -200,6 +213,7 @@ export function useCategorization(apiKey: string): CategorizationState {
     lastCategorizedMode,
     modeChanged,
     uncategorizedCount,
+    percentCategorized,
     showCategorizeBtn,
     setAppState,
     abortRef,

--- a/src/hooks/useCategorization.ts
+++ b/src/hooks/useCategorization.ts
@@ -62,13 +62,19 @@ export function useCategorization(apiKey: string): CategorizationState {
 
   const nonTransferCount = allTransactions.filter((tx) => tx.category !== 'Transfer').length
 
-  const uncategorizedCount = modeChanged
-    ? nonTransferCount
-    : allTransactions.filter((tx) => tx.subcategory === '' && tx.category !== 'Transfer').length
+  const actualUncategorizedCount =
+    allTransactions.filter((tx) => tx.subcategory === '' && tx.category !== 'Transfer').length
 
-  const percentCategorized = nonTransferCount > 0
-    ? Math.round(((nonTransferCount - uncategorizedCount) / nonTransferCount) * 100)
-    : 0
+  const uncategorizedCount = modeChanged ? nonTransferCount : actualUncategorizedCount
+
+  // Based on actualUncategorizedCount (not the modeChanged-inflated uncategorizedCount) and
+  // capped below 100 while any transaction remains uncategorized, so the banner never claims
+  // full coverage for a mode switch or a rounding-up remainder.
+  const percentCategorized = nonTransferCount === 0
+    ? 0
+    : actualUncategorizedCount === 0
+      ? 100
+      : Math.min(99, Math.round(((nonTransferCount - actualUncategorizedCount) / nonTransferCount) * 100))
 
   const showCategorizeBtn =
     (uncategorizedCount > 0 || modeChanged) && !!apiKey && appState !== 'categorizing'

--- a/src/lib/categorize.ts
+++ b/src/lib/categorize.ts
@@ -311,11 +311,6 @@ export async function categorizeTransactions(
   /** 'simple' | 'detailed' — used as cache key discriminator */
   mode = 'simple',
 ): Promise<CategorizationResult[]> {
-  const client = new Anthropic({
-    apiKey,
-    dangerouslyAllowBrowser: true,
-  })
-
   const total = transactions.length
   const allResults: CategorizationResult[] = []
   let done = 0
@@ -351,6 +346,14 @@ export async function categorizeTransactions(
     batches.push(cacheMisses.slice(i, i + BATCH_SIZE))
   }
 
+  // Constructed lazily — a keyed run where everything resolves offline/cache should never
+  // pay for a client it doesn't use.
+  let client: Anthropic | null = null
+  const getClient = (): Anthropic => {
+    if (!client) client = new Anthropic({ apiKey, dangerouslyAllowBrowser: true })
+    return client
+  }
+
   const runBatch = async (batch: Transaction[]): Promise<CategorizationResult[]> => {
     if (signal?.aborted) throw new Error('Categorization cancelled.')
     const items = batch.map((tx) => ({ id: tx.id, description: tx.description, amount: tx.amount }))
@@ -361,7 +364,7 @@ export async function categorizeTransactions(
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
       if (signal?.aborted) throw new Error('Categorization cancelled.')
       try {
-        const response = await client.messages.create({
+        const response = await getClient().messages.create({
           model: 'claude-sonnet-4-6',
           max_tokens: 4096,
           system: mode === 'detailed' ? DETAILED_SYSTEM_PROMPT : SYSTEM_PROMPT,

--- a/src/lib/classification.test.ts
+++ b/src/lib/classification.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { isUnclassifiedDefault, displayCategory } from './classification'
+import type { Transaction } from './types'
+
+function makeTx(overrides: Partial<Transaction>): Transaction {
+  return {
+    id: 'tx-1',
+    date: new Date('2024-01-15'),
+    description: 'TEST MERCHANT',
+    amount: 100,
+    type: 'debit',
+    category: 'Other',
+    subcategory: '',
+    sourceFile: 'test.csv',
+    ...overrides,
+  }
+}
+
+describe('isUnclassifiedDefault', () => {
+  it('is true for a debit transaction still at the Other/blank default', () => {
+    expect(isUnclassifiedDefault(makeTx({ type: 'debit', category: 'Other', subcategory: '' }))).toBe(true)
+  })
+
+  it('is true for a credit transaction still at the Income/blank default', () => {
+    expect(isUnclassifiedDefault(makeTx({ type: 'credit', category: 'Income', subcategory: '' }))).toBe(true)
+  })
+
+  it('is true for a credit transaction left at Other/blank by the Claude-failure fallback', () => {
+    expect(isUnclassifiedDefault(makeTx({ type: 'credit', category: 'Other', subcategory: '' }))).toBe(true)
+  })
+
+  it('is false once a subcategory has been assigned', () => {
+    expect(isUnclassifiedDefault(makeTx({ type: 'debit', category: 'Other', subcategory: 'Other' }))).toBe(false)
+  })
+
+  it('is false for a genuinely classified category', () => {
+    expect(isUnclassifiedDefault(makeTx({ type: 'debit', category: 'Dining', subcategory: '' }))).toBe(false)
+  })
+})
+
+describe('displayCategory', () => {
+  it('returns the override when one exists, even for an unclassified-default transaction', () => {
+    const tx = makeTx({ id: 'tx-1', type: 'debit', category: 'Other', subcategory: '' })
+    expect(displayCategory(tx, { 'tx-1': 'Shopping' })).toBe('Shopping')
+  })
+
+  it('returns "Uncategorized" for an unclassified-default transaction with no override', () => {
+    const tx = makeTx({ id: 'tx-1', type: 'debit', category: 'Other', subcategory: '' })
+    expect(displayCategory(tx, {})).toBe('Uncategorized')
+  })
+
+  it('returns the raw category for a classified transaction with no override', () => {
+    const tx = makeTx({ id: 'tx-1', type: 'debit', category: 'Dining', subcategory: 'Restaurant' })
+    expect(displayCategory(tx, {})).toBe('Dining')
+  })
+})

--- a/src/lib/classification.ts
+++ b/src/lib/classification.ts
@@ -1,0 +1,26 @@
+import type { Transaction } from './types'
+
+/**
+ * A transaction still sitting at parser.ts's type-based default (Income for credit / Other
+ * for debit) with no subcategory has not been touched by any classification layer yet. This
+ * also covers the categorize.ts Claude-failure fallback, which writes {category: 'Other',
+ * subcategory: ''} for any transaction (debit or credit) missing from a batch response.
+ */
+export function isUnclassifiedDefault(tx: Transaction): boolean {
+  return (
+    tx.subcategory === '' &&
+    (tx.category === 'Other' || (tx.type === 'credit' && tx.category === 'Income'))
+  )
+}
+
+/**
+ * The category a transaction should display as: the user's override if present, otherwise
+ * "Uncategorized" for still-unclassified transactions instead of silently blending them into
+ * a real category. Shared by the Sankey, visibility toggle, and transaction table so they
+ * agree on the same name (docs/product-review-fable.md §5 PR-2's "Uncategorized" sink node).
+ */
+export function displayCategory(tx: Transaction, overrides: Record<string, string>): string {
+  const overrideCategory = overrides[tx.id]
+  if (overrideCategory !== undefined) return overrideCategory
+  return isUnclassifiedDefault(tx) ? 'Uncategorized' : tx.category
+}

--- a/src/lib/sankey.test.ts
+++ b/src/lib/sankey.test.ts
@@ -181,3 +181,71 @@ describe('buildSankeyData — detailed mode', () => {
     expect(savingsLink).toBeDefined()
   })
 })
+
+describe('buildSankeyData — Uncategorized sink (offline-first partial categorization)', () => {
+  it('routes a debit transaction still at the parser default (Other, no subcategory) to cat:Uncategorized', () => {
+    const txns = [
+      INCOME_TX,
+      makeTx({ id: 'tx-1', category: 'Other', subcategory: '', amount: 150 }),
+    ]
+    const data = buildSankeyData(txns, {})
+    const nodeIds = data.nodes.map((n) => n.id)
+    expect(nodeIds).toContain('cat:Uncategorized')
+    expect(nodeIds).not.toContain('cat:Other')
+    const node = data.nodes.find((n) => n.id === 'cat:Uncategorized')
+    expect(node?.value).toBe(150)
+  })
+
+  it('does not route a transaction genuinely classified as Other (has a subcategory) to Uncategorized', () => {
+    const txns = [
+      INCOME_TX,
+      makeTx({ id: 'tx-1', category: 'Other', subcategory: 'Miscellaneous', amount: 150 }),
+    ]
+    const data = buildSankeyData(txns, {})
+    const nodeIds = data.nodes.map((n) => n.id)
+    expect(nodeIds).toContain('cat:Other')
+    expect(nodeIds).not.toContain('cat:Uncategorized')
+  })
+
+  it('an explicit user override on an unclassified transaction wins over the Uncategorized fallback', () => {
+    const txns = [
+      INCOME_TX,
+      makeTx({ id: 'tx-1', category: 'Other', subcategory: '', amount: 150 }),
+    ]
+    const data = buildSankeyData(txns, { 'tx-1': 'Groceries' })
+    const nodeIds = data.nodes.map((n) => n.id)
+    expect(nodeIds).toContain('cat:Groceries')
+    expect(nodeIds).not.toContain('cat:Uncategorized')
+  })
+
+  it('still excludes Transfer-category transactions entirely (never routed to Uncategorized)', () => {
+    const txns = [
+      INCOME_TX,
+      makeTx({ id: 'tx-1', category: 'Transfer', subcategory: '', amount: 500 }),
+      makeTx({ id: 'tx-2', category: 'Dining', subcategory: 'Restaurant', amount: 50 }),
+    ]
+    const data = buildSankeyData(txns, {})
+    const nodeIds = data.nodes.map((n) => n.id)
+    expect(nodeIds).not.toContain('cat:Uncategorized')
+    expect(nodeIds).not.toContain('cat:Transfer')
+  })
+
+  it('an unclassified credit (Income default, no subcategory) still counts as income, not an expense node', () => {
+    const txns = [
+      makeTx({
+        id: 'tx-1',
+        description: 'UNKNOWN CREDIT SOURCE',
+        type: 'credit',
+        category: 'Income',
+        subcategory: '',
+        amount: 200,
+      }),
+    ]
+    const data = buildSankeyData(txns, {})
+    expect(data.totalIncome).toBe(200)
+    const nodeIds = data.nodes.map((n) => n.id)
+    // No expense node at all — the only 'cat:' node is the unspent-income Savings node
+    expect(nodeIds).not.toContain('cat:Uncategorized')
+    expect(nodeIds).not.toContain('cat:Income')
+  })
+})

--- a/src/lib/sankey.ts
+++ b/src/lib/sankey.ts
@@ -47,6 +47,9 @@ const CATEGORY_COLORS: Record<string, string> = {
   Health: '#90cdf4',
   Subscriptions: '#fed7aa',
   Other: '#a0aec0',
+  // Distinct from Other — this is the offline-classification remainder, not a real category
+  // (docs/product-review-fable.md §5 PR-2's "Uncategorized" sink node).
+  Uncategorized: '#718096',
 }
 
 const INCOME_COLOR = '#68d391'
@@ -64,11 +67,23 @@ export function buildSankeyData(
 ): SankeyData {
   const nodeColors = { ...CATEGORY_COLORS, ...extraNodeColors }
 
-  // Apply overrides
-  const txns = transactions.map((tx) => ({
-    ...tx,
-    category: overrides[tx.id] ?? tx.category,
-  }))
+  // Apply overrides. A transaction still sitting at parser.ts's type-based default
+  // (Income for credit / Other for debit) with no subcategory has not been touched by any
+  // classification layer yet — route it to a distinct "Uncategorized" sink rather than
+  // silently blending it into a real category (docs/product-review-fable.md §5 PR-2).
+  // A transaction genuinely classified as Other/Income with a blank subcategory (e.g. an
+  // LLM response that omitted one) is the one rare case this can't distinguish — same
+  // ambiguity the pre-existing `tx.subcategory || tx.category` detailed-mode fallback had.
+  const txns = transactions.map((tx) => {
+    const overrideCategory = overrides[tx.id]
+    if (overrideCategory !== undefined) return { ...tx, category: overrideCategory }
+    const isUnclassifiedDefault =
+      tx.subcategory === '' &&
+      ((tx.type === 'debit' && tx.category === 'Other') ||
+        (tx.type === 'credit' && tx.category === 'Income'))
+    if (isUnclassifiedDefault) return { ...tx, category: 'Uncategorized' }
+    return tx
+  })
 
   // Filter out transfers
   const nonTransfer = txns.filter((tx) => tx.category !== 'Transfer')

--- a/src/lib/sankey.ts
+++ b/src/lib/sankey.ts
@@ -1,6 +1,7 @@
 import type { Transaction } from './types'
 import { EXPENSE_CATEGORIES } from './types'
 import { normalizeVendorName, normalizeSource } from './normalize'
+import { isUnclassifiedDefault } from './classification'
 
 export interface VendorTotal {
   name: string
@@ -67,21 +68,17 @@ export function buildSankeyData(
 ): SankeyData {
   const nodeColors = { ...CATEGORY_COLORS, ...extraNodeColors }
 
-  // Apply overrides. A transaction still sitting at parser.ts's type-based default
-  // (Income for credit / Other for debit) with no subcategory has not been touched by any
-  // classification layer yet — route it to a distinct "Uncategorized" sink rather than
-  // silently blending it into a real category (docs/product-review-fable.md §5 PR-2).
-  // A transaction genuinely classified as Other/Income with a blank subcategory (e.g. an
-  // LLM response that omitted one) is the one rare case this can't distinguish — same
-  // ambiguity the pre-existing `tx.subcategory || tx.category` detailed-mode fallback had.
+  // Apply overrides. isUnclassifiedDefault (shared with the visibility toggle and
+  // TransactionTable so all surfaces agree — see lib/classification.ts) routes transactions
+  // that haven't been touched by any classification layer to a distinct "Uncategorized" sink
+  // rather than silently blending them into a real category (docs/product-review-fable.md §5
+  // PR-2). A transaction genuinely classified as Other with a blank subcategory (e.g. an LLM
+  // response that omitted one) is the one rare case this can't distinguish — same ambiguity
+  // the pre-existing `tx.subcategory || tx.category` detailed-mode fallback had.
   const txns = transactions.map((tx) => {
     const overrideCategory = overrides[tx.id]
     if (overrideCategory !== undefined) return { ...tx, category: overrideCategory }
-    const isUnclassifiedDefault =
-      tx.subcategory === '' &&
-      ((tx.type === 'debit' && tx.category === 'Other') ||
-        (tx.type === 'credit' && tx.category === 'Income'))
-    if (isUnclassifiedDefault) return { ...tx, category: 'Uncategorized' }
+    if (isUnclassifiedDefault(tx)) return { ...tx, category: 'Uncategorized' }
     return tx
   })
 


### PR DESCRIPTION
## Summary

Merges classification PR-3 (§2.C) and product-review PR-2 into one change: the free, key-free classification layers now run during `handleFiles`, so a Sankey renders before any Claude API key exists.

**Spec sources:**
- `docs/classification-improvement-fable.md` §2.C, §4 "PR-3"
- `docs/product-review-fable.md` §5 "PR-2"

## What changed

- `useCategorization.ts` — `handleFiles` now runs `classifyByMerchant` (via the unified `merchant.ts` normalizer from the prior PR) on every non-transfer transaction, unconditionally, alongside the already key-free transfer detection. Transactions already classified (by this layer or by Claude) are never re-classified when more files are added. Added `percentCategorized` to the hook's returned state.
- `sankey.ts` — `buildSankeyData` now routes a transaction still sitting at the parser's type-based default (`Other` for debit / `Income` for credit) with no subcategory to a distinct `Uncategorized` sink node/color, instead of silently blending it into a real category. An explicit user override still wins over this fallback, and `Transfer` transactions are unaffected (still filtered out entirely).
- `App.tsx` — Sankey rendering is un-gated from the API key (it was already gated only on `hasCategorized`, which now flips true from offline classification alone). Replaced the old "No API key set" banner with an on-device coverage banner (`"N% categorized on-device. Add a Claude API key to categorize the rest."`), shown only when no key is set and a remainder exists. Relabeled the Claude button to `"Categorize remaining N with Claude"`, shown only when a key is present and a remainder exists.

## Acceptance criteria

- [x] Dropping sample-data CSVs with no API key renders a Sankey with ≥80% of transactions categorized and zero network requests — `src/App.test.tsx` asserts this against `bofa-credit-card.csv` (measured 91% offline coverage) via a `fetch` spy.
- [x] Percent-categorized is shown — the coverage banner (`src/App.test.tsx`, `src/hooks/useCategorization.test.ts`).
- [x] The Claude button appears only for the remainder — gated on `showCategorizeBtn` (present key + nonzero `uncategorizedCount`), covered in both test files.
- [x] All existing tests pass — 420/420 (`npm test`), plus `npm run lint` and `npm run build` are clean.

Manually verified in a running dev server via Playwright: dropping `bofa-credit-card.csv` with no key shows "91% categorized on-device..." and a Sankey with an `Uncategorized $2,083` node; adding a key shows "Categorize remaining 17 with Claude" with zero network calls until the button is clicked.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (420 passed)
- [x] Manual verification in a real browser (Playwright) for both the no-key and with-key paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)