### PR TITLE
feat(classify): harvest bank-provided category columns (PR-5)

### DIFF
--- a/sample-data/labeled/adversarial-probes.csv
+++ b/sample-data/labeled/adversarial-probes.csv
@@ -1,11 +1,11 @@
-sourceFile,description,amount,type,category,subcategory
-adversarial-probes.csv,SHELL BEACH CAFE SAN LUIS OBISPO,25,debit,Dining,Restaurant
-adversarial-probes.csv,O2 ARENA LONDON EVENT,25,debit,Entertainment,Concert/Event
-adversarial-probes.csv,PANDORA JEWELRY #442,25,debit,Shopping,Department Store
-adversarial-probes.csv,STEAM ROOM DAY SPA,25,debit,Health,Doctor/Medical
-adversarial-probes.csv,GAP INSURANCE PREMIUM AUTO,25,debit,Transport,Auto Insurance
-adversarial-probes.csv,RIVERSIDE ELECTRIC CO-OP,25,debit,Housing,Utilities
-adversarial-probes.csv,BOOTS AND SADDLES WESTERN WEAR,25,debit,Shopping,Clothing
-adversarial-probes.csv,MARATHON SPORTS RUNNING SHOES,25,debit,Shopping,Clothing
-adversarial-probes.csv,USAA TRANSFER TO CHECKING,25,debit,Transfer,Transfer
-adversarial-probes.csv,ACH CREDIT ACME CORP,25,credit,Income,Payroll
+sourceFile,description,amount,type,category,subcategory,bankCategory
+adversarial-probes.csv,SHELL BEACH CAFE SAN LUIS OBISPO,25,debit,Dining,Restaurant,
+adversarial-probes.csv,O2 ARENA LONDON EVENT,25,debit,Entertainment,Concert/Event,
+adversarial-probes.csv,PANDORA JEWELRY #442,25,debit,Shopping,Department Store,
+adversarial-probes.csv,STEAM ROOM DAY SPA,25,debit,Health,Doctor/Medical,
+adversarial-probes.csv,GAP INSURANCE PREMIUM AUTO,25,debit,Transport,Auto Insurance,
+adversarial-probes.csv,RIVERSIDE ELECTRIC CO-OP,25,debit,Housing,Utilities,
+adversarial-probes.csv,BOOTS AND SADDLES WESTERN WEAR,25,debit,Shopping,Clothing,
+adversarial-probes.csv,MARATHON SPORTS RUNNING SHOES,25,debit,Shopping,Clothing,
+adversarial-probes.csv,USAA TRANSFER TO CHECKING,25,debit,Transfer,Transfer,
+adversarial-probes.csv,ACH CREDIT ACME CORP,25,credit,Income,Payroll,

--- a/sample-data/labeled/fixtures-gold.csv
+++ b/sample-data/labeled/fixtures-gold.csv
@@ -1,1004 +1,1004 @@
-sourceFile,description,amount,type,category,subcategory
-amex-gold.csv,GRUBHUB INC,34.2,debit,Dining,Food Delivery
-amex-gold.csv,AMAZON.COM,129,debit,Shopping,Online Retail
-amex-gold.csv,DELTA AIR LINES,387.5,debit,Travel,Flight
-amex-gold.csv,WHOLEFOODS #SF,92.15,debit,Groceries,Specialty Food
-amex-gold.csv,MARRIOTT HOTELS,312,debit,Travel,Hotel
-amex-gold.csv,UBER *TRIP,18.4,debit,Transport,Rideshare
-amex-gold.csv,APPLE STORE,999,debit,Shopping,Electronics
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,2200,credit,Transfer,Transfer
-amex-gold.csv,SWEETGREEN,16.75,debit,Dining,Fast Food
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,AMAZON.COM REFUND,45,credit,Shopping,Online Retail
-amex-gold.csv,INSTACART,78.32,debit,Groceries,Grocery Delivery
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,RESY *RESTAURANT,145,debit,Dining,Restaurant
-amex-gold.csv,DELTA AIR LINES,214,debit,Travel,Flight
-amex-gold.csv,WHOLEFOODS #SF,88.4,debit,Groceries,Specialty Food
-amex-gold.csv,AMAZON.COM,67.49,debit,Shopping,Online Retail
-amex-gold.csv,GRUBHUB INC,28.9,debit,Dining,Food Delivery
-amex-gold.csv,SWEETGREEN,15.25,debit,Dining,Fast Food
-amex-gold.csv,APPLE.COM/BILL,2.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,ANTHROPIC *API,23.47,debit,Subscriptions,Software/SaaS
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1800,credit,Transfer,Transfer
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,UBER *TRIP,22.1,debit,Transport,Rideshare
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,INSTACART,94.15,debit,Groceries,Grocery Delivery
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,BLUE BOTTLE COFFEE,9.5,debit,Dining,Coffee Shop
-amex-gold.csv,WHOLEFOODS #SF,81.7,debit,Groceries,Specialty Food
-amex-gold.csv,AMAZON.COM,44.99,debit,Shopping,Online Retail
-amex-gold.csv,SWEETGREEN,17,debit,Dining,Fast Food
-amex-gold.csv,GRUBHUB INC,31.4,debit,Dining,Food Delivery
-amex-gold.csv,APPLE STORE,49,debit,Shopping,Electronics
-amex-gold.csv,ANTHROPIC *API,18.92,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1600,credit,Transfer,Transfer
-amex-gold.csv,DELTA AIR LINES REFUND,100,credit,Travel,Flight
-amex-gold.csv,INSTACART,71.88,debit,Groceries,Grocery Delivery
-amex-gold.csv,UBER *TRIP,15.6,debit,Transport,Rideshare
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,BLUE BOTTLE COFFEE,8.75,debit,Dining,Coffee Shop
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,RESY *RESTAURANT,210,debit,Dining,Restaurant
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1400,credit,Transfer,Transfer
-amex-gold.csv,GRUBHUB INC,41.5,debit,Dining,Food Delivery
-amex-gold.csv,SWEETGREEN,16.25,debit,Dining,Fast Food
-amex-gold.csv,DELTA AIR LINES,285,debit,Travel,Flight
-amex-gold.csv,MARRIOTT NYC,420,debit,Travel,Hotel
-amex-gold.csv,WHOLEFOODS #SF,78.9,debit,Groceries,Specialty Food
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,ANTHROPIC *API,31.5,debit,Subscriptions,Software/SaaS
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,UBER *TRIP,24.3,debit,Transport,Rideshare
-amex-gold.csv,SWEETGREEN,17.8,debit,Dining,Fast Food
-amex-gold.csv,INSTACART,88.45,debit,Groceries,Grocery Delivery
-amex-gold.csv,AMAZON.COM,55,debit,Shopping,Online Retail
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1450,credit,Transfer,Transfer
-amex-gold.csv,GRUBHUB INC,38.9,debit,Dining,Food Delivery
-amex-gold.csv,SWEETGREEN,15.8,debit,Dining,Fast Food
-amex-gold.csv,WHOLEFOODS #SF,84.2,debit,Groceries,Specialty Food
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,UBER *TRIP,19.5,debit,Transport,Rideshare
-amex-gold.csv,ANTHROPIC *API,27.8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,INSTACART,72.3,debit,Groceries,Grocery Delivery
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,BLUE BOTTLE COFFEE,9.5,debit,Dining,Coffee Shop
-amex-gold.csv,SWEETGREEN,16.9,debit,Dining,Fast Food
-amex-gold.csv,AMAZON.COM,67.44,debit,Shopping,Online Retail
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1350,credit,Transfer,Transfer
-amex-gold.csv,GRUBHUB INC,44.2,debit,Dining,Food Delivery
-amex-gold.csv,DELTA AIR LINES,385,debit,Travel,Flight
-amex-gold.csv,AIRBNB,650,debit,Travel,Vacation Rental
-amex-gold.csv,WHOLEFOODS #SF,92.3,debit,Groceries,Specialty Food
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,UBER *TRIP,31.8,debit,Transport,Rideshare
-amex-gold.csv,ANTHROPIC *API,35.2,debit,Subscriptions,Software/SaaS
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,SWEETGREEN,18.9,debit,Dining,Fast Food
-amex-gold.csv,INSTACART,95.4,debit,Groceries,Grocery Delivery
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1800,credit,Transfer,Transfer
-amex-gold.csv,GRUBHUB INC,36.8,debit,Dining,Food Delivery
-amex-gold.csv,SWEETGREEN,17.2,debit,Dining,Fast Food
-amex-gold.csv,WHOLEFOODS #SF,88.75,debit,Groceries,Specialty Food
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,UBER *TRIP,22.4,debit,Transport,Rideshare
-amex-gold.csv,ANTHROPIC *API,29.6,debit,Subscriptions,Software/SaaS
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,INSTACART,81.2,debit,Groceries,Grocery Delivery
-amex-gold.csv,BLUE BOTTLE COFFEE,9.25,debit,Dining,Coffee Shop
-amex-gold.csv,AMAZON.COM,44.99,debit,Shopping,Online Retail
-amex-gold.csv,SWEETGREEN,16.5,debit,Dining,Fast Food
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1400,credit,Transfer,Transfer
-amex-gold.csv,GRUBHUB INC,39.5,debit,Dining,Food Delivery
-amex-gold.csv,SWEETGREEN,15.9,debit,Dining,Fast Food
-amex-gold.csv,WHOLEFOODS #SF,91.4,debit,Groceries,Specialty Food
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,UBER *TRIP,28.7,debit,Transport,Rideshare
-amex-gold.csv,ANTHROPIC *API,41.3,debit,Subscriptions,Software/SaaS
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,INSTACART,76.8,debit,Groceries,Grocery Delivery
-amex-gold.csv,RESY *RESTAURANT,125,debit,Dining,Restaurant
-amex-gold.csv,AMAZON.COM,33.99,debit,Shopping,Online Retail
-amex-gold.csv,SWEETGREEN,18.2,debit,Dining,Fast Food
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1550,credit,Transfer,Transfer
-amex-gold.csv,GRUBHUB INC,42.6,debit,Dining,Food Delivery
-amex-gold.csv,DELTA AIR LINES,310,debit,Travel,Flight
-amex-gold.csv,HILTON HOTELS,380,debit,Travel,Hotel
-amex-gold.csv,SWEETGREEN,16.8,debit,Dining,Fast Food
-amex-gold.csv,WHOLEFOODS #SF,85.3,debit,Groceries,Specialty Food
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,ANTHROPIC *API,38.7,debit,Subscriptions,Software/SaaS
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,UBER *TRIP,19.9,debit,Transport,Rideshare
-amex-gold.csv,INSTACART,88.6,debit,Groceries,Grocery Delivery
-amex-gold.csv,BLUE BOTTLE COFFEE,9.75,debit,Dining,Coffee Shop
-amex-gold.csv,SWEETGREEN,17.4,debit,Dining,Fast Food
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1700,credit,Transfer,Transfer
-amex-gold.csv,GRUBHUB INC,37.4,debit,Dining,Food Delivery
-amex-gold.csv,SWEETGREEN,16.1,debit,Dining,Fast Food
-amex-gold.csv,WHOLEFOODS #SF,87.5,debit,Groceries,Specialty Food
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,UBER *TRIP,23.8,debit,Transport,Rideshare
-amex-gold.csv,ANTHROPIC *API,33.2,debit,Subscriptions,Software/SaaS
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,INSTACART,79.4,debit,Groceries,Grocery Delivery
-amex-gold.csv,RESY *RESTAURANT,95,debit,Dining,Restaurant
-amex-gold.csv,AMAZON.COM,78.88,debit,Shopping,Online Retail
-amex-gold.csv,SWEETGREEN,17.9,debit,Dining,Fast Food
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1450,credit,Transfer,Transfer
-amex-gold.csv,GRUBHUB INC,45.8,debit,Dining,Food Delivery
-amex-gold.csv,SWEETGREEN,17.5,debit,Dining,Fast Food
-amex-gold.csv,WHOLEFOODS #SF,118.4,debit,Groceries,Specialty Food
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,AMAZON.COM,245,debit,Shopping,Online Retail
-amex-gold.csv,ANTHROPIC *API,47.2,debit,Subscriptions,Software/SaaS
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,UBER *TRIP,28.4,debit,Transport,Rideshare
-amex-gold.csv,INSTACART,105.6,debit,Groceries,Grocery Delivery
-amex-gold.csv,DELTA AIR LINES,420,debit,Travel,Flight
-amex-gold.csv,RESY *RESTAURANT,310,debit,Dining,Restaurant
-amex-gold.csv,AMAZON.COM,189,debit,Shopping,Online Retail
-amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,2200,credit,Transfer,Transfer
-amex-gold.csv,GRUBHUB INC,48.9,debit,Dining,Food Delivery
-amex-gold.csv,SWEETGREEN,18.2,debit,Dining,Fast Food
-amex-gold.csv,WHOLEFOODS #SF,145.8,debit,Groceries,Specialty Food
-amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS
-amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym
-amex-gold.csv,AMAZON.COM,312,debit,Shopping,Online Retail
-amex-gold.csv,ANTHROPIC *API,52.3,debit,Subscriptions,Software/SaaS
-amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS
-amex-gold.csv,UBER *TRIP,34.2,debit,Transport,Rideshare
-amex-gold.csv,INSTACART,128.4,debit,Groceries,Grocery Delivery
-amex-gold.csv,DELTA AIR LINES,485,debit,Travel,Flight
-amex-gold.csv,RESY *RESTAURANT,420,debit,Dining,Restaurant
-amex-gold.csv,APPLE STORE,599,debit,Shopping,Electronics
-bofa-credit-card.csv,WHOLEFDS MKT #10,87.43,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,SHELL SERVICE STATION,68.2,debit,Transport,Gas Station
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,42.99,debit,Shopping,Online Retail
-bofa-credit-card.csv,UBER* PENDING,14.75,debit,Transport,Rideshare
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,PAYMENT THANK YOU,1200,credit,Transfer,Transfer
-bofa-credit-card.csv,CVS PHARMACY,23.58,debit,Health,Pharmacy
-bofa-credit-card.csv,STARBUCKS STORE 08432,6.75,debit,Dining,Coffee Shop
-bofa-credit-card.csv,COMCAST CABLE COMM,109.99,debit,Housing,Internet/Cable
-bofa-credit-card.csv,TRADER JOES #123,63.41,debit,Groceries,Specialty Food
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,18,credit,Shopping,Online Retail
-bofa-credit-card.csv,CHIPOTLE MEXICAN,12.85,debit,Dining,Fast Food
-bofa-credit-card.csv,ATT*BILL PAYMENT,89,debit,Housing,Phone Bill
-bofa-credit-card.csv,WHOLEFDS MKT #10,91.17,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,SHELL SERVICE STATION,72.4,debit,Transport,Gas Station
-bofa-credit-card.csv,HULU LLC,17.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,134,debit,Shopping,Online Retail
-bofa-credit-card.csv,LYFT *RIDE,11.5,debit,Transport,Rideshare
-bofa-credit-card.csv,PAYMENT THANK YOU,1400,credit,Transfer,Transfer
-bofa-credit-card.csv,TARGET STORE 00024831,57.32,debit,Shopping,Department Store
-bofa-credit-card.csv,CHEESECAKE FACTORY,78.9,debit,Dining,Restaurant
-bofa-credit-card.csv,COSTCO GAS #0472,58.2,debit,Transport,Gas Station
-bofa-credit-card.csv,TRADER JOES #123,55.88,debit,Groceries,Specialty Food
-bofa-credit-card.csv,PAYPAL *FREELANCE,350,credit,Income,Freelance
-bofa-credit-card.csv,CVS PHARMACY,14.29,debit,Health,Pharmacy
-bofa-credit-card.csv,DOORDASH*DASHPASS,9.99,debit,Dining,Food Delivery
-bofa-credit-card.csv,WHOLEFDS MKT #10,79.65,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,SHELL SERVICE STATION,68.8,debit,Transport,Gas Station
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,29.99,debit,Shopping,Online Retail
-bofa-credit-card.csv,UBER EATS,34.2,debit,Dining,Food Delivery
-bofa-credit-card.csv,STARBUCKS STORE 08432,7.25,debit,Dining,Coffee Shop
-bofa-credit-card.csv,PAYMENT THANK YOU,1300,credit,Transfer,Transfer
-bofa-credit-card.csv,COSTCO WHSE #0472,187.43,debit,Groceries,Warehouse Club
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,APPLE.COM/BILL,2.99,debit,Subscriptions,Software/SaaS
-bofa-credit-card.csv,TRADER JOES #123,68.92,debit,Groceries,Specialty Food
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,DOORDASH*DOORDASH,28.5,debit,Dining,Food Delivery
-bofa-credit-card.csv,ADOBE INC,54.99,debit,Subscriptions,Software/SaaS
-bofa-credit-card.csv,WHOLEFDS MKT #10,86.4,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,COSTCO GAS #0472,62.1,debit,Transport,Gas Station
-bofa-credit-card.csv,CHEESECAKE FACTORY,71.4,debit,Dining,Restaurant
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,56.78,debit,Shopping,Online Retail
-bofa-credit-card.csv,UBER EATS,29.3,debit,Dining,Food Delivery
-bofa-credit-card.csv,PAYMENT THANK YOU,1200,credit,Transfer,Transfer
-bofa-credit-card.csv,TARGET STORE 00024831,103.44,debit,Shopping,Department Store
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,DOORDASH*DOORDASH,24.8,debit,Dining,Food Delivery
-bofa-credit-card.csv,TRADER JOES #123,68.2,debit,Groceries,Specialty Food
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,CVS PHARMACY,18.75,debit,Health,Pharmacy
-bofa-credit-card.csv,STARBUCKS STORE 08432,7.5,debit,Dining,Coffee Shop
-bofa-credit-card.csv,MCDONALDS #4821,9.25,debit,Dining,Fast Food
-bofa-credit-card.csv,WHOLEFDS MKT #10,91.22,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,SHELL SERVICE STATION,66.8,debit,Transport,Gas Station
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,78.99,debit,Shopping,Online Retail
-bofa-credit-card.csv,CHIPOTLE MEXICAN,13.45,debit,Dining,Fast Food
-bofa-credit-card.csv,LYFT *RIDE,16.8,debit,Transport,Rideshare
-bofa-credit-card.csv,PAYMENT THANK YOU,1400,credit,Transfer,Transfer
-bofa-credit-card.csv,TRADER JOES #123,75.6,debit,Groceries,Specialty Food
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,TARGET STORE 00024831,65.44,debit,Shopping,Department Store
-bofa-credit-card.csv,DOORDASH*DOORDASH,31.5,debit,Dining,Food Delivery
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,STARBUCKS STORE 08432,8.25,debit,Dining,Coffee Shop
-bofa-credit-card.csv,APPLE.COM/BILL,2.99,debit,Subscriptions,Software/SaaS
-bofa-credit-card.csv,COSTCO GAS #0472,61.4,debit,Transport,Gas Station
-bofa-credit-card.csv,WHOLEFDS MKT #10,88.75,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,COSTCO GAS #0472,67.2,debit,Transport,Gas Station
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,44.33,debit,Shopping,Online Retail
-bofa-credit-card.csv,SWEETGREEN,16.8,debit,Dining,Fast Food
-bofa-credit-card.csv,LYFT *RIDE,14.5,debit,Transport,Rideshare
-bofa-credit-card.csv,PAYMENT THANK YOU,1350,credit,Transfer,Transfer
-bofa-credit-card.csv,TRADER JOES #123,71.3,debit,Groceries,Specialty Food
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,UBER EATS,33.4,debit,Dining,Food Delivery
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,TARGET STORE 00024831,78.55,debit,Shopping,Department Store
-bofa-credit-card.csv,STARBUCKS STORE 08432,7.75,debit,Dining,Coffee Shop
-bofa-credit-card.csv,CVS PHARMACY,24.9,debit,Health,Pharmacy
-bofa-credit-card.csv,DOORDASH*DOORDASH,22.8,debit,Dining,Food Delivery
-bofa-credit-card.csv,WHOLEFDS MKT #10,96.4,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,SHELL SERVICE STATION,74.8,debit,Transport,Gas Station
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,89.44,debit,Shopping,Online Retail
-bofa-credit-card.csv,CHIPOTLE MEXICAN,15.2,debit,Dining,Fast Food
-bofa-credit-card.csv,COSTCO GAS #0472,68.3,debit,Transport,Gas Station
-bofa-credit-card.csv,PAYMENT THANK YOU,1300,credit,Transfer,Transfer
-bofa-credit-card.csv,TRADER JOES #123,74.8,debit,Groceries,Specialty Food
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,TOTAL WINE AND MORE,52.4,debit,Entertainment,Nightlife
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,TARGET STORE 00024831,71.22,debit,Shopping,Department Store
-bofa-credit-card.csv,STARBUCKS STORE 08432,8,debit,Dining,Coffee Shop
-bofa-credit-card.csv,UBER EATS,29.9,debit,Dining,Food Delivery
-bofa-credit-card.csv,CVS PHARMACY,19.4,debit,Health,Pharmacy
-bofa-credit-card.csv,WHOLEFDS MKT #10,89.9,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,COSTCO GAS #0472,71.6,debit,Transport,Gas Station
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,127.5,debit,Shopping,Online Retail
-bofa-credit-card.csv,SWEETGREEN,16.4,debit,Dining,Fast Food
-bofa-credit-card.csv,LYFT *RIDE,18.2,debit,Transport,Rideshare
-bofa-credit-card.csv,PAYMENT THANK YOU,1500,credit,Transfer,Transfer
-bofa-credit-card.csv,TRADER JOES #123,77.3,debit,Groceries,Specialty Food
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,CHEESECAKE FACTORY,84.6,debit,Dining,Restaurant
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,TARGET STORE 00024831,55.33,debit,Shopping,Department Store
-bofa-credit-card.csv,STARBUCKS STORE 08432,8.75,debit,Dining,Coffee Shop
-bofa-credit-card.csv,CVS PHARMACY,21.8,debit,Health,Pharmacy
-bofa-credit-card.csv,DOORDASH*DOORDASH,28.5,debit,Dining,Food Delivery
-bofa-credit-card.csv,WHOLEFDS MKT #10,84.2,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,SHELL SERVICE STATION,68.4,debit,Transport,Gas Station
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,34.99,debit,Shopping,Online Retail
-bofa-credit-card.csv,CHIPOTLE MEXICAN,14.8,debit,Dining,Fast Food
-bofa-credit-card.csv,COSTCO GAS #0472,65.9,debit,Transport,Gas Station
-bofa-credit-card.csv,PAYMENT THANK YOU,1400,credit,Transfer,Transfer
-bofa-credit-card.csv,TRADER JOES #123,69.8,debit,Groceries,Specialty Food
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,COSTCO WHSE #0472,168.44,debit,Groceries,Warehouse Club
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,TARGET STORE 00024831,82.55,debit,Shopping,Department Store
-bofa-credit-card.csv,STARBUCKS STORE 08432,7.5,debit,Dining,Coffee Shop
-bofa-credit-card.csv,CVS PHARMACY,28.9,debit,Health,Pharmacy
-bofa-credit-card.csv,DOORDASH*DOORDASH,24.8,debit,Dining,Food Delivery
-bofa-credit-card.csv,WHOLEFDS MKT #10,92.3,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,COSTCO GAS #0472,73.2,debit,Transport,Gas Station
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,67.44,debit,Shopping,Online Retail
-bofa-credit-card.csv,CHIPOTLE MEXICAN,15.3,debit,Dining,Fast Food
-bofa-credit-card.csv,LYFT *RIDE,21.4,debit,Transport,Rideshare
-bofa-credit-card.csv,PAYMENT THANK YOU,1350,credit,Transfer,Transfer
-bofa-credit-card.csv,TRADER JOES #123,82.6,debit,Groceries,Specialty Food
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,TARGET STORE 00024831,98.44,debit,Shopping,Department Store
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,STARBUCKS STORE 08432,8.25,debit,Dining,Coffee Shop
-bofa-credit-card.csv,CVS PHARMACY,42.18,debit,Health,Pharmacy
-bofa-credit-card.csv,DOORDASH*DOORDASH,31.2,debit,Dining,Food Delivery
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,88.99,debit,Shopping,Online Retail
-bofa-credit-card.csv,WHOLEFDS MKT #10,118.4,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,SHELL SERVICE STATION,72.8,debit,Transport,Gas Station
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,156.78,debit,Shopping,Online Retail
-bofa-credit-card.csv,CHIPOTLE MEXICAN,15.9,debit,Dining,Fast Food
-bofa-credit-card.csv,LYFT *RIDE,19.5,debit,Transport,Rideshare
-bofa-credit-card.csv,PAYMENT THANK YOU,1600,credit,Transfer,Transfer
-bofa-credit-card.csv,TRADER JOES #123,91.3,debit,Groceries,Specialty Food
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,TARGET STORE 00024831,224.88,debit,Shopping,Department Store
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,STARBUCKS STORE 08432,9.25,debit,Dining,Coffee Shop
-bofa-credit-card.csv,CVS PHARMACY,35.8,debit,Health,Pharmacy
-bofa-credit-card.csv,DOORDASH*DOORDASH,38.5,debit,Dining,Food Delivery
-bofa-credit-card.csv,BEST BUY 00287,179.99,debit,Shopping,Electronics
-bofa-credit-card.csv,WHOLEFDS MKT #10,122.5,debit,Groceries,Specialty Food
-bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-bofa-credit-card.csv,COSTCO GAS #0472,70.3,debit,Transport,Gas Station
-bofa-credit-card.csv,AMAZON MKTPLACE PMTS,287.44,debit,Shopping,Online Retail
-bofa-credit-card.csv,CHIPOTLE MEXICAN,16.8,debit,Dining,Fast Food
-bofa-credit-card.csv,LYFT *RIDE,24.8,debit,Transport,Rideshare
-bofa-credit-card.csv,PAYMENT THANK YOU,1800,credit,Transfer,Transfer
-bofa-credit-card.csv,TRADER JOES #123,98.4,debit,Groceries,Specialty Food
-bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-bofa-credit-card.csv,TARGET STORE 00024831,144.55,debit,Shopping,Department Store
-bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym
-bofa-credit-card.csv,STARBUCKS STORE 08432,11.5,debit,Dining,Coffee Shop
-bofa-credit-card.csv,CVS PHARMACY,28.9,debit,Health,Pharmacy
-bofa-credit-card.csv,DOORDASH*DOORDASH,34.8,debit,Dining,Food Delivery
-bofa-credit-card.csv,BEST BUY 00287,229.99,debit,Shopping,Electronics
-bofa-credit-card.csv,DELTA AIR LINES TICKET,389,debit,Travel,Flight
-bofa-credit-card.csv,MARRIOTT SAN JOSE CONF CTR,312,debit,Travel,Hotel
-bofa-credit-card.csv,OAK & VINE RESTAURANT,94.5,debit,Dining,Restaurant
-bofa-credit-card.csv,AMAZON.COM OFFICE SUPPLIES,67.89,debit,Shopping,Online Retail
-bofa-credit-card.csv,ASPEN DENTAL ASSOCIATES,425,debit,Health,Dentist
-bofa-credit-card.csv,DELTA AIR LINES TICKET,445,debit,Travel,Flight
-bofa-credit-card.csv,HILTON GARDEN INN,289,debit,Travel,Hotel
-bofa-credit-card.csv,MARKET BISTRO RESTAURANT,112.4,debit,Dining,Restaurant
-bofa-credit-card.csv,AMAZON.COM*9XM2K1PR,58.44,debit,Shopping,Online Retail
-bofa-credit-card.csv,DR SARAH CHEN MD OFFICE,250,debit,Health,Doctor/Medical
-bofa-credit-card.csv,GITHUB INC,100,debit,Subscriptions,Software/SaaS
-bofa-credit-card.csv,VISION SOURCE EYE CARE,195,debit,Health,Vision
-bofa-credit-card.csv,DELTA AIR LINES TICKET,512,debit,Travel,Flight
-bofa-credit-card.csv,WESTIN HOTEL,398,debit,Travel,Hotel
-bofa-credit-card.csv,TASTE OF ITALY RISTORANTE,87.6,debit,Dining,Restaurant
-bofa-credit-card.csv,AMAZON.COM*4PT8N2VX,142.33,debit,Shopping,Online Retail
-bofa-credit-card.csv,NOTION LABS INC,96,debit,Subscriptions,Software/SaaS
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,87.43,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,68.2,debit,Transport,Gas Station
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,AMAZON.COM*2K7LM9PQ4,42.99,debit,Shopping,Online Retail
-chase-checking.csv,UBER* TRIP,14.75,debit,Transport,Rideshare
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,CVS PHARMACY #7824,23.58,debit,Health,Pharmacy
-chase-checking.csv,STARBUCKS #08432,6.75,debit,Dining,Coffee Shop
-chase-checking.csv,PG&E ELECTRIC BILL,142.18,debit,Housing,Utilities
-chase-checking.csv,TRADER JOE S #123,63.41,debit,Groceries,Specialty Food
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,AMZN MKTP US*3R9KP REFUND,18,credit,Shopping,Online Retail
-chase-checking.csv,CHIPOTLE MEXICAN GRILL,12.85,debit,Dining,Fast Food
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,INTEREST PAYMENT,4.21,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,91.17,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,72.4,debit,Transport,Gas Station
-chase-checking.csv,HULU,17.99,debit,Subscriptions,Streaming
-chase-checking.csv,AMAZON.COM*9X2MN5TR8,134,debit,Shopping,Online Retail
-chase-checking.csv,LYFT *RIDE MON 5PM,11.5,debit,Transport,Rideshare
-chase-checking.csv,VALENTIN RESTAURANT,98,debit,Dining,Restaurant
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,TARGET 00024831,57.32,debit,Shopping,Department Store
-chase-checking.csv,CHEESECAKE FACTORY,78.9,debit,Dining,Restaurant
-chase-checking.csv,PG&E ELECTRIC BILL,138.55,debit,Housing,Utilities
-chase-checking.csv,TRADER JOE S #123,55.88,debit,Groceries,Specialty Food
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,CVS PHARMACY #7824,14.29,debit,Health,Pharmacy
-chase-checking.csv,INTEREST PAYMENT,4.35,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,79.65,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,AMAZON.COM*7K4JL2QP1,29.99,debit,Shopping,Online Retail
-chase-checking.csv,UBER EATS,34.2,debit,Dining,Food Delivery
-chase-checking.csv,STARBUCKS #08432,7.25,debit,Dining,Coffee Shop
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,COSTCO WHSE #0472,187.43,debit,Groceries,Warehouse Club
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,PG&E ELECTRIC BILL,138.55,debit,Housing,Utilities
-chase-checking.csv,TRADER JOE S #123,68.92,debit,Groceries,Specialty Food
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,APPLE.COM/BILL,2.99,debit,Subscriptions,Software/SaaS
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,VENMO PAYMENT,80,debit,Transfer,Transfer
-chase-checking.csv,INTEREST PAYMENT,4.18,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,82.33,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,69.9,debit,Transport,Gas Station
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,STATE TAX REFUND,812,credit,Income,Tax Refund
-chase-checking.csv,AMAZON.COM*3P8NX7YR2,56.78,debit,Shopping,Online Retail
-chase-checking.csv,STARBUCKS #08432,6.75,debit,Dining,Coffee Shop
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,TRADER JOE S #123,61.2,debit,Groceries,Specialty Food
-chase-checking.csv,PG&E ELECTRIC BILL,88.92,debit,Housing,Utilities
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,LYFT *RIDE,18.9,debit,Transport,Rideshare
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,WALGREENS STORE #4201,31.47,debit,Health,Pharmacy
-chase-checking.csv,INTEREST PAYMENT,4.42,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,94.67,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,67.9,debit,Transport,Gas Station
-chase-checking.csv,AMAZON.COM*5H2KL9MQ7,78.99,debit,Shopping,Online Retail
-chase-checking.csv,STARBUCKS #08432,7.5,debit,Dining,Coffee Shop
-chase-checking.csv,TRADER JOE S #123,72.14,debit,Groceries,Specialty Food
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,CHIPOTLE MEXICAN GRILL,14.2,debit,Dining,Fast Food
-chase-checking.csv,PG&E ELECTRIC BILL,91.1,debit,Housing,Utilities
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,TARGET 00024831,67.44,debit,Shopping,Department Store
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,TRADER JOE S #123,55.3,debit,Groceries,Specialty Food
-chase-checking.csv,INTEREST PAYMENT,4.61,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,88.91,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,74.2,debit,Transport,Gas Station
-chase-checking.csv,AMAZON.COM PRIME MEMBERSHIP,139,debit,Subscriptions,Streaming
-chase-checking.csv,STARBUCKS #08432,6.25,debit,Dining,Coffee Shop
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,TRADER JOE S #123,65.77,debit,Groceries,Specialty Food
-chase-checking.csv,AMAZON.COM*8Q3NV5WP1,45.33,debit,Shopping,Online Retail
-chase-checking.csv,PG&E ELECTRIC BILL,118.43,debit,Housing,Utilities
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,UBER EATS,28.5,debit,Dining,Food Delivery
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,INTEREST PAYMENT,4.55,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,102.48,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,TOTAL WINE & MORE,48.75,debit,Entertainment,Nightlife
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,AMAZON.COM*1L6PQ2TK9,33.47,debit,Shopping,Online Retail
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,71.6,debit,Transport,Gas Station
-chase-checking.csv,STARBUCKS #08432,7,debit,Dining,Coffee Shop
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,TRADER JOE S #123,70.33,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,PG&E ELECTRIC BILL,158.92,debit,Housing,Utilities
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,TARGET 00024831,44.22,debit,Shopping,Department Store
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,CVS PHARMACY #7824,22.4,debit,Health,Pharmacy
-chase-checking.csv,INTEREST PAYMENT,4.72,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,85.6,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,69.4,debit,Transport,Gas Station
-chase-checking.csv,AMAZON.COM*4R7MN8PQ3,127.5,debit,Shopping,Online Retail
-chase-checking.csv,STARBUCKS #08432,7.25,debit,Dining,Coffee Shop
-chase-checking.csv,TRADER JOE S #123,75.44,debit,Groceries,Specialty Food
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,CVS PHARMACY #7824,18.75,debit,Health,Pharmacy
-chase-checking.csv,UBER EATS,35.8,debit,Dining,Food Delivery
-chase-checking.csv,PG&E ELECTRIC BILL,172.3,debit,Housing,Utilities
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,TRADER JOE S #123,62.1,debit,Groceries,Specialty Food
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,CHIPOTLE MEXICAN GRILL,13.9,debit,Dining,Fast Food
-chase-checking.csv,INTEREST PAYMENT,4.83,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,92.28,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,66.8,debit,Transport,Gas Station
-chase-checking.csv,AMAZON.COM*9W2PK5QR6,89.99,debit,Shopping,Online Retail
-chase-checking.csv,STARBUCKS #08432,7.75,debit,Dining,Coffee Shop
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,TRADER JOE S #123,58.6,debit,Groceries,Specialty Food
-chase-checking.csv,PG&E ELECTRIC BILL,118.75,debit,Housing,Utilities
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,COSTCO WHSE #0472,156.78,debit,Groceries,Warehouse Club
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,WALGREENS STORE #4201,28.5,debit,Health,Pharmacy
-chase-checking.csv,INTEREST PAYMENT,5.1,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,89.4,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,73.3,debit,Transport,Gas Station
-chase-checking.csv,AMAZON.COM*6T4NM2KW8,67.44,debit,Shopping,Online Retail
-chase-checking.csv,STARBUCKS #08432,7.75,debit,Dining,Coffee Shop
-chase-checking.csv,TRADER JOE S #123,77.22,debit,Groceries,Specialty Food
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,CHIPOTLE MEXICAN GRILL,14.75,debit,Dining,Fast Food
-chase-checking.csv,TARGET 00024831,88.55,debit,Shopping,Department Store
-chase-checking.csv,PG&E ELECTRIC BILL,102.18,debit,Housing,Utilities
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,CVS PHARMACY #7824,42.18,debit,Health,Pharmacy
-chase-checking.csv,INTEREST PAYMENT,5.24,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,108.3,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,72.1,debit,Transport,Gas Station
-chase-checking.csv,AMAZON.COM*2P5KQ9TN4,156.78,debit,Shopping,Online Retail
-chase-checking.csv,STARBUCKS #08432,7.25,debit,Dining,Coffee Shop
-chase-checking.csv,TRADER JOE S #123,88.4,debit,Groceries,Specialty Food
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,CHIPOTLE MEXICAN GRILL,14.9,debit,Dining,Fast Food
-chase-checking.csv,PG&E ELECTRIC BILL,121.44,debit,Housing,Utilities
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,TRADER JOE S #123,143.6,debit,Groceries,Specialty Food
-chase-checking.csv,TARGET 00024831,224.88,debit,Shopping,Department Store
-chase-checking.csv,INTEREST PAYMENT,5.35,credit,Income,Interest
-chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-chase-checking.csv,WHOLEFDS #10 MARKET ST,108.55,debit,Groceries,Specialty Food
-chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming
-chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll
-chase-checking.csv,YEAR END BONUS,1000,credit,Income,Bonus
-chase-checking.csv,AMAZON.COM*8N3LQ7PK5,287.44,debit,Shopping,Online Retail
-chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,70.8,debit,Transport,Gas Station
-chase-checking.csv,STARBUCKS #08432,9.5,debit,Dining,Coffee Shop
-chase-checking.csv,TRADER JOE S #123,95.2,debit,Groceries,Specialty Food
-chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming
-chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer
-chase-checking.csv,CHIPOTLE MEXICAN GRILL,16.4,debit,Dining,Fast Food
-chase-checking.csv,PG&E ELECTRIC BILL,145.33,debit,Housing,Utilities
-chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym
-chase-checking.csv,WHOLEFDS #10 MARKET ST,178.4,debit,Groceries,Specialty Food
-chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill
-chase-checking.csv,TARGET 00024831,112.33,debit,Shopping,Department Store
-chase-checking.csv,INTEREST PAYMENT,5.48,credit,Income,Interest
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance
-chase-checking.csv,CHARITY WATER DONATION,50,debit,Other,Donation
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance
-chase-checking.csv,AMERICAN RED CROSS DONATION,100,debit,Other,Donation
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance
-chase-checking.csv,COUNTY PROPERTY TAX PAYMENT,2200,debit,Other,Property Tax
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,2200,credit,Income,Freelance
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1800,credit,Income,Freelance
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance
-chase-checking.csv,COUNTY PROPERTY TAX PAYMENT,2200,debit,Other,Property Tax
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance
-chase-checking.csv,CHARITY WATER DONATION,50,debit,Other,Donation
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,2000,credit,Income,Freelance
-chase-checking.csv,DOCTORS MEDICAL GROUP,180,debit,Health,Doctor/Medical
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance
-chase-checking.csv,AMERICAN RED CROSS DONATION,150,debit,Other,Donation
-chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,87.43,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,68.2,debit,Transport,Gas Station
-credit-union-checking.csv,AMAZON.COM,42.99,debit,Shopping,Online Retail
-credit-union-checking.csv,UBER TRIP,14.75,debit,Transport,Rideshare
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,CVS PHARMACY,23.58,debit,Health,Pharmacy
-credit-union-checking.csv,STARBUCKS,6.75,debit,Dining,Coffee Shop
-credit-union-checking.csv,PG&E,142.18,debit,Housing,Utilities
-credit-union-checking.csv,TRADER JOES,63.41,debit,Groceries,Specialty Food
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,AMAZON REFUND,18,credit,Shopping,Online Retail
-credit-union-checking.csv,CHIPOTLE,12.85,debit,Dining,Fast Food
-credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill
-credit-union-checking.csv,INTEREST EARNED,4.21,credit,Income,Interest
-credit-union-checking.csv,RENTER INSURANCE ALLSTATE,125,debit,Housing,Insurance
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,91.17,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,72.4,debit,Transport,Gas Station
-credit-union-checking.csv,HULU,17.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,AMAZON.COM,134,debit,Shopping,Online Retail
-credit-union-checking.csv,LYFT,11.5,debit,Transport,Rideshare
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,TARGET,57.32,debit,Shopping,Department Store
-credit-union-checking.csv,CHEESECAKE FACTORY,78.9,debit,Dining,Restaurant
-credit-union-checking.csv,COMCAST,109.99,debit,Housing,Internet/Cable
-credit-union-checking.csv,TRADER JOES,55.88,debit,Groceries,Specialty Food
-credit-union-checking.csv,ZELLE PAYMENT TO ALEX,650,debit,Transfer,Transfer
-credit-union-checking.csv,CVS PHARMACY,14.29,debit,Health,Pharmacy
-credit-union-checking.csv,DOORDASH,9.99,debit,Dining,Food Delivery
-credit-union-checking.csv,INTEREST EARNED,3.98,credit,Income,Interest
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,79.65,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,68.8,debit,Transport,Gas Station
-credit-union-checking.csv,AMAZON.COM,29.99,debit,Shopping,Online Retail
-credit-union-checking.csv,UBER EATS,34.2,debit,Dining,Food Delivery
-credit-union-checking.csv,STARBUCKS,7.25,debit,Dining,Coffee Shop
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,COSTCO,187.43,debit,Groceries,Warehouse Club
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,PG&E,138.55,debit,Housing,Utilities
-credit-union-checking.csv,TRADER JOES,68.92,debit,Groceries,Specialty Food
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,APPLE.COM/BILL,2.99,debit,Subscriptions,Software/SaaS
-credit-union-checking.csv,SIDE JOB PAYMENT,850,credit,Income,Side Income
-credit-union-checking.csv,INTEREST EARNED,4.44,credit,Income,Interest
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,82.33,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,67.8,debit,Transport,Gas Station
-credit-union-checking.csv,AMAZON.COM,44.99,debit,Shopping,Online Retail
-credit-union-checking.csv,STARBUCKS,6.75,debit,Dining,Coffee Shop
-credit-union-checking.csv,TRADER JOES,65.2,debit,Groceries,Specialty Food
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,CHIPOTLE,14.4,debit,Dining,Fast Food
-credit-union-checking.csv,PG&E,82.44,debit,Housing,Utilities
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill
-credit-union-checking.csv,WALGREENS,31.47,debit,Health,Pharmacy
-credit-union-checking.csv,LYFT,12.5,debit,Transport,Rideshare
-credit-union-checking.csv,INTEREST EARNED,4.35,credit,Income,Interest
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,88.4,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,67.2,debit,Transport,Gas Station
-credit-union-checking.csv,AMAZON.COM,44.99,debit,Shopping,Online Retail
-credit-union-checking.csv,STARBUCKS,7.25,debit,Dining,Coffee Shop
-credit-union-checking.csv,TRADER JOES,72.15,debit,Groceries,Specialty Food
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,UBER EATS,32.5,debit,Dining,Food Delivery
-credit-union-checking.csv,PG&E,91.1,debit,Housing,Utilities
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,TARGET,78.44,debit,Shopping,Department Store
-credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill
-credit-union-checking.csv,TRADER JOES,55.3,debit,Groceries,Specialty Food
-credit-union-checking.csv,INTEREST EARNED,4.52,credit,Income,Interest
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,90.15,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,73.4,debit,Transport,Gas Station
-credit-union-checking.csv,AMAZON.COM,38.99,debit,Shopping,Online Retail
-credit-union-checking.csv,STARBUCKS,6.5,debit,Dining,Coffee Shop
-credit-union-checking.csv,TRADER JOES,68.3,debit,Groceries,Specialty Food
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,SIDE JOB PAYMENT,950,credit,Income,Side Income
-credit-union-checking.csv,CHIPOTLE,15.2,debit,Dining,Fast Food
-credit-union-checking.csv,PG&E,118.43,debit,Housing,Utilities
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,LYFT,16.8,debit,Transport,Rideshare
-credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill
-credit-union-checking.csv,UBER EATS,27.4,debit,Dining,Food Delivery
-credit-union-checking.csv,INTEREST EARNED,4.68,credit,Income,Interest
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,95.5,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,75.2,debit,Transport,Gas Station
-credit-union-checking.csv,AMAZON.COM,89.44,debit,Shopping,Online Retail
-credit-union-checking.csv,STARBUCKS,7,debit,Dining,Coffee Shop
-credit-union-checking.csv,TRADER JOES,71.88,debit,Groceries,Specialty Food
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,CHIPOTLE,14.85,debit,Dining,Fast Food
-credit-union-checking.csv,PG&E,158.92,debit,Housing,Utilities
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,TARGET,66.33,debit,Shopping,Department Store
-credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill
-credit-union-checking.csv,CVS PHARMACY,22.4,debit,Health,Pharmacy
-credit-union-checking.csv,INTEREST EARNED,4.77,credit,Income,Interest
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,88.9,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,71.3,debit,Transport,Gas Station
-credit-union-checking.csv,AMAZON.COM,145,debit,Shopping,Online Retail
-credit-union-checking.csv,STARBUCKS,7.25,debit,Dining,Coffee Shop
-credit-union-checking.csv,TRADER JOES,75.44,debit,Groceries,Specialty Food
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,UBER EATS,35.8,debit,Dining,Food Delivery
-credit-union-checking.csv,PG&E,172.3,debit,Housing,Utilities
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,TRADER JOES,62.1,debit,Groceries,Specialty Food
-credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill
-credit-union-checking.csv,STARBUCKS,8.5,debit,Dining,Coffee Shop
-credit-union-checking.csv,INTEREST EARNED,4.93,credit,Income,Interest
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,83.2,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,67.8,debit,Transport,Gas Station
-credit-union-checking.csv,SIDE JOB PAYMENT,925,credit,Income,Side Income
-credit-union-checking.csv,AMAZON.COM,34.99,debit,Shopping,Online Retail
-credit-union-checking.csv,STARBUCKS,7.5,debit,Dining,Coffee Shop
-credit-union-checking.csv,TRADER JOES,58.66,debit,Groceries,Specialty Food
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,CHIPOTLE,15.4,debit,Dining,Fast Food
-credit-union-checking.csv,PG&E,135.75,debit,Housing,Utilities
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,COSTCO WHSE,178.33,debit,Groceries,Warehouse Club
-credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill
-credit-union-checking.csv,CVS PHARMACY,28.5,debit,Health,Pharmacy
-credit-union-checking.csv,INTEREST EARNED,5.1,credit,Income,Interest
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,90.45,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,73.9,debit,Transport,Gas Station
-credit-union-checking.csv,AMAZON.COM,67.44,debit,Shopping,Online Retail
-credit-union-checking.csv,STARBUCKS,7.75,debit,Dining,Coffee Shop
-credit-union-checking.csv,TRADER JOES,80.22,debit,Groceries,Specialty Food
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,TARGET,88.55,debit,Shopping,Department Store
-credit-union-checking.csv,PG&E,102.18,debit,Housing,Utilities
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,LYFT,19.2,debit,Transport,Rideshare
-credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill
-credit-union-checking.csv,CVS PHARMACY,42.18,debit,Health,Pharmacy
-credit-union-checking.csv,INTEREST EARNED,5.24,credit,Income,Interest
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,108.3,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,72.1,debit,Transport,Gas Station
-credit-union-checking.csv,AMAZON.COM,156.78,debit,Shopping,Online Retail
-credit-union-checking.csv,STARBUCKS,7.25,debit,Dining,Coffee Shop
-credit-union-checking.csv,TRADER JOES,88.4,debit,Groceries,Specialty Food
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,CHIPOTLE,14.9,debit,Dining,Fast Food
-credit-union-checking.csv,PG&E,121.44,debit,Housing,Utilities
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill
-credit-union-checking.csv,TRADER JOES,143.6,debit,Groceries,Specialty Food
-credit-union-checking.csv,TARGET,224.88,debit,Shopping,Department Store
-credit-union-checking.csv,INTEREST EARNED,5.35,credit,Income,Interest
-credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent
-credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll
-credit-union-checking.csv,WHOLEFDS MARKET,112.5,debit,Groceries,Specialty Food
-credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming
-credit-union-checking.csv,SHELL OIL 57442,70.8,debit,Transport,Gas Station
-credit-union-checking.csv,AMAZON.COM,287.44,debit,Shopping,Online Retail
-credit-union-checking.csv,STARBUCKS,9.5,debit,Dining,Coffee Shop
-credit-union-checking.csv,SIDE JOB PAYMENT,875,credit,Income,Side Income
-credit-union-checking.csv,TRADER JOES,95.2,debit,Groceries,Specialty Food
-credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming
-credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer
-credit-union-checking.csv,CHIPOTLE,16.4,debit,Dining,Fast Food
-credit-union-checking.csv,PG&E,145.33,debit,Housing,Utilities
-credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym
-credit-union-checking.csv,WHOLEFDS MARKET,178.4,debit,Groceries,Specialty Food
-credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill
-credit-union-checking.csv,TARGET,144.55,debit,Shopping,Department Store
-credit-union-checking.csv,INTEREST EARNED,5.48,credit,Income,Interest
-monzo-uk.csv,Tesco Express,12.45,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,6.8,debit,Dining,Coffee Shop
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Deliveroo,22.9,debit,Dining,Food Delivery
-monzo-uk.csv,Amazon,34.99,debit,Shopping,Online Retail
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Sainsbury's,45.32,debit,Groceries,Supermarket
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Costa Coffee,4.5,debit,Dining,Coffee Shop
-monzo-uk.csv,Shell,58.4,debit,Transport,Gas Station
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,M&S Food,28.75,debit,Groceries,Specialty Food
-monzo-uk.csv,Monzo Flex,250,debit,Transfer,Transfer
-monzo-uk.csv,Tesco Express,14.9,debit,Groceries,Supermarket
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Amazon,67.5,debit,Shopping,Online Retail
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Sainsbury's,52.18,debit,Groceries,Supermarket
-monzo-uk.csv,Deliveroo,19.5,debit,Dining,Food Delivery
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Costa Coffee,4.75,debit,Dining,Coffee Shop
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,M&S Food,31.4,debit,Groceries,Specialty Food
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,Restaurant 1847,88,debit,Dining,Restaurant
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Tesco,61.22,debit,Groceries,Supermarket
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Amazon,22,debit,Shopping,Online Retail
-monzo-uk.csv,Tesco Express,16.4,debit,Groceries,Supermarket
-monzo-uk.csv,Deliveroo,21.8,debit,Dining,Food Delivery
-monzo-uk.csv,Costa Coffee,5.25,debit,Dining,Coffee Shop
-monzo-uk.csv,Sainsbury's,45.2,debit,Groceries,Supermarket
-monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Tesco Express,14.9,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,6.8,debit,Dining,Coffee Shop
-monzo-uk.csv,Deliveroo,22.5,debit,Dining,Food Delivery
-monzo-uk.csv,Amazon,34.99,debit,Shopping,Online Retail
-monzo-uk.csv,Costa Coffee,4.75,debit,Dining,Coffee Shop
-monzo-uk.csv,Sainsbury's,52.4,debit,Groceries,Supermarket
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,M&S Food,31.4,debit,Groceries,Specialty Food
-monzo-uk.csv,Tesco,61.22,debit,Groceries,Supermarket
-monzo-uk.csv,Deliveroo,19.5,debit,Dining,Food Delivery
-monzo-uk.csv,Amazon,22,debit,Shopping,Online Retail
-monzo-uk.csv,Uber Eats,18.9,debit,Dining,Food Delivery
-monzo-uk.csv,Costa Coffee,5.25,debit,Dining,Coffee Shop
-monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Tesco Express,12.45,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,6.5,debit,Dining,Coffee Shop
-monzo-uk.csv,Sainsbury's,48.3,debit,Groceries,Supermarket
-monzo-uk.csv,Amazon,67.5,debit,Shopping,Online Retail
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Costa Coffee,4.5,debit,Dining,Coffee Shop
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,M&S Food,28.75,debit,Groceries,Specialty Food
-monzo-uk.csv,Deliveroo,24.8,debit,Dining,Food Delivery
-monzo-uk.csv,Tesco,55.3,debit,Groceries,Supermarket
-monzo-uk.csv,Uber Eats,21.5,debit,Dining,Food Delivery
-monzo-uk.csv,Restaurant 1847,88,debit,Dining,Restaurant
-monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Tesco Express,14.9,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,7.2,debit,Dining,Coffee Shop
-monzo-uk.csv,Amazon,44.99,debit,Shopping,Online Retail
-monzo-uk.csv,Sainsbury's,52.18,debit,Groceries,Supermarket
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Costa Coffee,5,debit,Dining,Coffee Shop
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,M&S Food,33.6,debit,Groceries,Specialty Food
-monzo-uk.csv,Deliveroo,19.5,debit,Dining,Food Delivery
-monzo-uk.csv,Tesco,48.2,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,6.8,debit,Dining,Coffee Shop
-monzo-uk.csv,Amazon,29.99,debit,Shopping,Online Retail
-monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Tesco Express,13.6,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,6.25,debit,Dining,Coffee Shop
-monzo-uk.csv,Sainsbury's,55.4,debit,Groceries,Supermarket
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Costa Coffee,4.75,debit,Dining,Coffee Shop
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,Deliveroo,28.4,debit,Dining,Food Delivery
-monzo-uk.csv,Tesco,62.1,debit,Groceries,Supermarket
-monzo-uk.csv,Amazon,34.99,debit,Shopping,Online Retail
-monzo-uk.csv,Restaurant,65,debit,Dining,Restaurant
-monzo-uk.csv,M&S Food,41.8,debit,Groceries,Specialty Food
-monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Tesco Express,12.45,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,6.8,debit,Dining,Coffee Shop
-monzo-uk.csv,Amazon,89.99,debit,Shopping,Online Retail
-monzo-uk.csv,Sainsbury's,47.3,debit,Groceries,Supermarket
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Costa Coffee,5.25,debit,Dining,Coffee Shop
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,M&S Food,35.6,debit,Groceries,Specialty Food
-monzo-uk.csv,Deliveroo,31.5,debit,Dining,Food Delivery
-monzo-uk.csv,Tesco,58.4,debit,Groceries,Supermarket
-monzo-uk.csv,Amazon,22,debit,Shopping,Online Retail
-monzo-uk.csv,Restaurant,78.5,debit,Dining,Restaurant
-monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Tesco Express,15.4,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,7,debit,Dining,Coffee Shop
-monzo-uk.csv,Amazon,145,debit,Shopping,Online Retail
-monzo-uk.csv,Sainsbury's,61.3,debit,Groceries,Supermarket
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Costa Coffee,4.5,debit,Dining,Coffee Shop
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,M&S Food,38.9,debit,Groceries,Specialty Food
-monzo-uk.csv,Deliveroo,25.8,debit,Dining,Food Delivery
-monzo-uk.csv,Tesco,53.2,debit,Groceries,Supermarket
-monzo-uk.csv,Amazon,67.5,debit,Shopping,Online Retail
-monzo-uk.csv,Pret A Manger,6.75,debit,Dining,Coffee Shop
-monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Tesco Express,13.85,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,6.5,debit,Dining,Coffee Shop
-monzo-uk.csv,Sainsbury's,54.8,debit,Groceries,Supermarket
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Costa Coffee,5,debit,Dining,Coffee Shop
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,Amazon,44.99,debit,Shopping,Online Retail
-monzo-uk.csv,M&S Food,32.4,debit,Groceries,Specialty Food
-monzo-uk.csv,Deliveroo,22.9,debit,Dining,Food Delivery
-monzo-uk.csv,Tesco,69.4,debit,Groceries,Supermarket
-monzo-uk.csv,Uber Eats,18.5,debit,Dining,Food Delivery
-monzo-uk.csv,Amazon,38.99,debit,Shopping,Online Retail
-monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Tesco Express,14.9,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,6.8,debit,Dining,Coffee Shop
-monzo-uk.csv,Amazon,78.99,debit,Shopping,Online Retail
-monzo-uk.csv,Sainsbury's,58.2,debit,Groceries,Supermarket
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Costa Coffee,5.5,debit,Dining,Coffee Shop
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,M&S Food,41.6,debit,Groceries,Specialty Food
-monzo-uk.csv,Deliveroo,33.5,debit,Dining,Food Delivery
-monzo-uk.csv,Tesco,71.2,debit,Groceries,Supermarket
-monzo-uk.csv,Amazon,55,debit,Shopping,Online Retail
-monzo-uk.csv,Uber Eats,24.8,debit,Dining,Food Delivery
-monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Tesco Express,16.4,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,7.5,debit,Dining,Coffee Shop
-monzo-uk.csv,Amazon,245,debit,Shopping,Online Retail
-monzo-uk.csv,Sainsbury's,78.5,debit,Groceries,Supermarket
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Costa Coffee,5.25,debit,Dining,Coffee Shop
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,M&S Food,55.8,debit,Groceries,Specialty Food
-monzo-uk.csv,Deliveroo,38.5,debit,Dining,Food Delivery
-monzo-uk.csv,Tesco,91.4,debit,Groceries,Supermarket
-monzo-uk.csv,Amazon,189.99,debit,Shopping,Online Retail
-monzo-uk.csv,Marks & Spencer,120,debit,Shopping,Clothing
-monzo-uk.csv,Pret A Manger,8.25,debit,Dining,Coffee Shop
-monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent
-monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll
-monzo-uk.csv,Tesco Express,18.4,debit,Groceries,Supermarket
-monzo-uk.csv,Pret A Manger,8.5,debit,Dining,Coffee Shop
-monzo-uk.csv,Amazon,312,debit,Shopping,Online Retail
-monzo-uk.csv,Sainsbury's,102.4,debit,Groceries,Supermarket
-monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming
-monzo-uk.csv,Costa Coffee,6,debit,Dining,Coffee Shop
-monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit
-monzo-uk.csv,Gym Membership,40,debit,Health,Gym
-monzo-uk.csv,M&S Food,88.5,debit,Groceries,Specialty Food
-monzo-uk.csv,Deliveroo,45.8,debit,Dining,Food Delivery
-monzo-uk.csv,Tesco,125.4,debit,Groceries,Supermarket
-monzo-uk.csv,Amazon,178,debit,Shopping,Online Retail
-monzo-uk.csv,Restaurant,195,debit,Dining,Restaurant
-monzo-uk.csv,Pret A Manger,7.75,debit,Dining,Coffee Shop
+sourceFile,description,amount,type,category,subcategory,bankCategory
+amex-gold.csv,GRUBHUB INC,34.2,debit,Dining,Food Delivery,
+amex-gold.csv,AMAZON.COM,129,debit,Shopping,Online Retail,
+amex-gold.csv,DELTA AIR LINES,387.5,debit,Travel,Flight,
+amex-gold.csv,WHOLEFOODS #SF,92.15,debit,Groceries,Specialty Food,
+amex-gold.csv,MARRIOTT HOTELS,312,debit,Travel,Hotel,
+amex-gold.csv,UBER *TRIP,18.4,debit,Transport,Rideshare,
+amex-gold.csv,APPLE STORE,999,debit,Shopping,Electronics,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,2200,credit,Transfer,Transfer,
+amex-gold.csv,SWEETGREEN,16.75,debit,Dining,Fast Food,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,AMAZON.COM REFUND,45,credit,Shopping,Online Retail,
+amex-gold.csv,INSTACART,78.32,debit,Groceries,Grocery Delivery,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,RESY *RESTAURANT,145,debit,Dining,Restaurant,
+amex-gold.csv,DELTA AIR LINES,214,debit,Travel,Flight,
+amex-gold.csv,WHOLEFOODS #SF,88.4,debit,Groceries,Specialty Food,
+amex-gold.csv,AMAZON.COM,67.49,debit,Shopping,Online Retail,
+amex-gold.csv,GRUBHUB INC,28.9,debit,Dining,Food Delivery,
+amex-gold.csv,SWEETGREEN,15.25,debit,Dining,Fast Food,
+amex-gold.csv,APPLE.COM/BILL,2.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,ANTHROPIC *API,23.47,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1800,credit,Transfer,Transfer,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,UBER *TRIP,22.1,debit,Transport,Rideshare,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,INSTACART,94.15,debit,Groceries,Grocery Delivery,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,BLUE BOTTLE COFFEE,9.5,debit,Dining,Coffee Shop,
+amex-gold.csv,WHOLEFOODS #SF,81.7,debit,Groceries,Specialty Food,
+amex-gold.csv,AMAZON.COM,44.99,debit,Shopping,Online Retail,
+amex-gold.csv,SWEETGREEN,17,debit,Dining,Fast Food,
+amex-gold.csv,GRUBHUB INC,31.4,debit,Dining,Food Delivery,
+amex-gold.csv,APPLE STORE,49,debit,Shopping,Electronics,
+amex-gold.csv,ANTHROPIC *API,18.92,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1600,credit,Transfer,Transfer,
+amex-gold.csv,DELTA AIR LINES REFUND,100,credit,Travel,Flight,
+amex-gold.csv,INSTACART,71.88,debit,Groceries,Grocery Delivery,
+amex-gold.csv,UBER *TRIP,15.6,debit,Transport,Rideshare,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,BLUE BOTTLE COFFEE,8.75,debit,Dining,Coffee Shop,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,RESY *RESTAURANT,210,debit,Dining,Restaurant,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1400,credit,Transfer,Transfer,
+amex-gold.csv,GRUBHUB INC,41.5,debit,Dining,Food Delivery,
+amex-gold.csv,SWEETGREEN,16.25,debit,Dining,Fast Food,
+amex-gold.csv,DELTA AIR LINES,285,debit,Travel,Flight,
+amex-gold.csv,MARRIOTT NYC,420,debit,Travel,Hotel,
+amex-gold.csv,WHOLEFOODS #SF,78.9,debit,Groceries,Specialty Food,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,ANTHROPIC *API,31.5,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,UBER *TRIP,24.3,debit,Transport,Rideshare,
+amex-gold.csv,SWEETGREEN,17.8,debit,Dining,Fast Food,
+amex-gold.csv,INSTACART,88.45,debit,Groceries,Grocery Delivery,
+amex-gold.csv,AMAZON.COM,55,debit,Shopping,Online Retail,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1450,credit,Transfer,Transfer,
+amex-gold.csv,GRUBHUB INC,38.9,debit,Dining,Food Delivery,
+amex-gold.csv,SWEETGREEN,15.8,debit,Dining,Fast Food,
+amex-gold.csv,WHOLEFOODS #SF,84.2,debit,Groceries,Specialty Food,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,UBER *TRIP,19.5,debit,Transport,Rideshare,
+amex-gold.csv,ANTHROPIC *API,27.8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,INSTACART,72.3,debit,Groceries,Grocery Delivery,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,BLUE BOTTLE COFFEE,9.5,debit,Dining,Coffee Shop,
+amex-gold.csv,SWEETGREEN,16.9,debit,Dining,Fast Food,
+amex-gold.csv,AMAZON.COM,67.44,debit,Shopping,Online Retail,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1350,credit,Transfer,Transfer,
+amex-gold.csv,GRUBHUB INC,44.2,debit,Dining,Food Delivery,
+amex-gold.csv,DELTA AIR LINES,385,debit,Travel,Flight,
+amex-gold.csv,AIRBNB,650,debit,Travel,Vacation Rental,
+amex-gold.csv,WHOLEFOODS #SF,92.3,debit,Groceries,Specialty Food,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,UBER *TRIP,31.8,debit,Transport,Rideshare,
+amex-gold.csv,ANTHROPIC *API,35.2,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,SWEETGREEN,18.9,debit,Dining,Fast Food,
+amex-gold.csv,INSTACART,95.4,debit,Groceries,Grocery Delivery,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1800,credit,Transfer,Transfer,
+amex-gold.csv,GRUBHUB INC,36.8,debit,Dining,Food Delivery,
+amex-gold.csv,SWEETGREEN,17.2,debit,Dining,Fast Food,
+amex-gold.csv,WHOLEFOODS #SF,88.75,debit,Groceries,Specialty Food,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,UBER *TRIP,22.4,debit,Transport,Rideshare,
+amex-gold.csv,ANTHROPIC *API,29.6,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,INSTACART,81.2,debit,Groceries,Grocery Delivery,
+amex-gold.csv,BLUE BOTTLE COFFEE,9.25,debit,Dining,Coffee Shop,
+amex-gold.csv,AMAZON.COM,44.99,debit,Shopping,Online Retail,
+amex-gold.csv,SWEETGREEN,16.5,debit,Dining,Fast Food,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1400,credit,Transfer,Transfer,
+amex-gold.csv,GRUBHUB INC,39.5,debit,Dining,Food Delivery,
+amex-gold.csv,SWEETGREEN,15.9,debit,Dining,Fast Food,
+amex-gold.csv,WHOLEFOODS #SF,91.4,debit,Groceries,Specialty Food,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,UBER *TRIP,28.7,debit,Transport,Rideshare,
+amex-gold.csv,ANTHROPIC *API,41.3,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,INSTACART,76.8,debit,Groceries,Grocery Delivery,
+amex-gold.csv,RESY *RESTAURANT,125,debit,Dining,Restaurant,
+amex-gold.csv,AMAZON.COM,33.99,debit,Shopping,Online Retail,
+amex-gold.csv,SWEETGREEN,18.2,debit,Dining,Fast Food,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1550,credit,Transfer,Transfer,
+amex-gold.csv,GRUBHUB INC,42.6,debit,Dining,Food Delivery,
+amex-gold.csv,DELTA AIR LINES,310,debit,Travel,Flight,
+amex-gold.csv,HILTON HOTELS,380,debit,Travel,Hotel,
+amex-gold.csv,SWEETGREEN,16.8,debit,Dining,Fast Food,
+amex-gold.csv,WHOLEFOODS #SF,85.3,debit,Groceries,Specialty Food,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,ANTHROPIC *API,38.7,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,UBER *TRIP,19.9,debit,Transport,Rideshare,
+amex-gold.csv,INSTACART,88.6,debit,Groceries,Grocery Delivery,
+amex-gold.csv,BLUE BOTTLE COFFEE,9.75,debit,Dining,Coffee Shop,
+amex-gold.csv,SWEETGREEN,17.4,debit,Dining,Fast Food,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1700,credit,Transfer,Transfer,
+amex-gold.csv,GRUBHUB INC,37.4,debit,Dining,Food Delivery,
+amex-gold.csv,SWEETGREEN,16.1,debit,Dining,Fast Food,
+amex-gold.csv,WHOLEFOODS #SF,87.5,debit,Groceries,Specialty Food,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,UBER *TRIP,23.8,debit,Transport,Rideshare,
+amex-gold.csv,ANTHROPIC *API,33.2,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,INSTACART,79.4,debit,Groceries,Grocery Delivery,
+amex-gold.csv,RESY *RESTAURANT,95,debit,Dining,Restaurant,
+amex-gold.csv,AMAZON.COM,78.88,debit,Shopping,Online Retail,
+amex-gold.csv,SWEETGREEN,17.9,debit,Dining,Fast Food,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,1450,credit,Transfer,Transfer,
+amex-gold.csv,GRUBHUB INC,45.8,debit,Dining,Food Delivery,
+amex-gold.csv,SWEETGREEN,17.5,debit,Dining,Fast Food,
+amex-gold.csv,WHOLEFOODS #SF,118.4,debit,Groceries,Specialty Food,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,AMAZON.COM,245,debit,Shopping,Online Retail,
+amex-gold.csv,ANTHROPIC *API,47.2,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,UBER *TRIP,28.4,debit,Transport,Rideshare,
+amex-gold.csv,INSTACART,105.6,debit,Groceries,Grocery Delivery,
+amex-gold.csv,DELTA AIR LINES,420,debit,Travel,Flight,
+amex-gold.csv,RESY *RESTAURANT,310,debit,Dining,Restaurant,
+amex-gold.csv,AMAZON.COM,189,debit,Shopping,Online Retail,
+amex-gold.csv,AUTOPAY PAYMENT - THANK YOU,2200,credit,Transfer,Transfer,
+amex-gold.csv,GRUBHUB INC,48.9,debit,Dining,Food Delivery,
+amex-gold.csv,SWEETGREEN,18.2,debit,Dining,Fast Food,
+amex-gold.csv,WHOLEFOODS #SF,145.8,debit,Groceries,Specialty Food,
+amex-gold.csv,ZOOM.US,14.99,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,EQUINOX FITNESS,180,debit,Health,Gym,
+amex-gold.csv,AMAZON.COM,312,debit,Shopping,Online Retail,
+amex-gold.csv,ANTHROPIC *API,52.3,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,NOTION.SO,8,debit,Subscriptions,Software/SaaS,
+amex-gold.csv,UBER *TRIP,34.2,debit,Transport,Rideshare,
+amex-gold.csv,INSTACART,128.4,debit,Groceries,Grocery Delivery,
+amex-gold.csv,DELTA AIR LINES,485,debit,Travel,Flight,
+amex-gold.csv,RESY *RESTAURANT,420,debit,Dining,Restaurant,
+amex-gold.csv,APPLE STORE,599,debit,Shopping,Electronics,
+bofa-credit-card.csv,WHOLEFDS MKT #10,87.43,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,SHELL SERVICE STATION,68.2,debit,Transport,Gas Station,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,42.99,debit,Shopping,Online Retail,
+bofa-credit-card.csv,UBER* PENDING,14.75,debit,Transport,Rideshare,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,PAYMENT THANK YOU,1200,credit,Transfer,Transfer,
+bofa-credit-card.csv,CVS PHARMACY,23.58,debit,Health,Pharmacy,
+bofa-credit-card.csv,STARBUCKS STORE 08432,6.75,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,COMCAST CABLE COMM,109.99,debit,Housing,Internet/Cable,
+bofa-credit-card.csv,TRADER JOES #123,63.41,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,18,credit,Shopping,Online Retail,
+bofa-credit-card.csv,CHIPOTLE MEXICAN,12.85,debit,Dining,Fast Food,
+bofa-credit-card.csv,ATT*BILL PAYMENT,89,debit,Housing,Phone Bill,
+bofa-credit-card.csv,WHOLEFDS MKT #10,91.17,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,SHELL SERVICE STATION,72.4,debit,Transport,Gas Station,
+bofa-credit-card.csv,HULU LLC,17.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,134,debit,Shopping,Online Retail,
+bofa-credit-card.csv,LYFT *RIDE,11.5,debit,Transport,Rideshare,
+bofa-credit-card.csv,PAYMENT THANK YOU,1400,credit,Transfer,Transfer,
+bofa-credit-card.csv,TARGET STORE 00024831,57.32,debit,Shopping,Department Store,
+bofa-credit-card.csv,CHEESECAKE FACTORY,78.9,debit,Dining,Restaurant,
+bofa-credit-card.csv,COSTCO GAS #0472,58.2,debit,Transport,Gas Station,
+bofa-credit-card.csv,TRADER JOES #123,55.88,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,PAYPAL *FREELANCE,350,credit,Income,Freelance,
+bofa-credit-card.csv,CVS PHARMACY,14.29,debit,Health,Pharmacy,
+bofa-credit-card.csv,DOORDASH*DASHPASS,9.99,debit,Dining,Food Delivery,
+bofa-credit-card.csv,WHOLEFDS MKT #10,79.65,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,SHELL SERVICE STATION,68.8,debit,Transport,Gas Station,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,29.99,debit,Shopping,Online Retail,
+bofa-credit-card.csv,UBER EATS,34.2,debit,Dining,Food Delivery,
+bofa-credit-card.csv,STARBUCKS STORE 08432,7.25,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,PAYMENT THANK YOU,1300,credit,Transfer,Transfer,
+bofa-credit-card.csv,COSTCO WHSE #0472,187.43,debit,Groceries,Warehouse Club,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,APPLE.COM/BILL,2.99,debit,Subscriptions,Software/SaaS,
+bofa-credit-card.csv,TRADER JOES #123,68.92,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,DOORDASH*DOORDASH,28.5,debit,Dining,Food Delivery,
+bofa-credit-card.csv,ADOBE INC,54.99,debit,Subscriptions,Software/SaaS,
+bofa-credit-card.csv,WHOLEFDS MKT #10,86.4,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,COSTCO GAS #0472,62.1,debit,Transport,Gas Station,
+bofa-credit-card.csv,CHEESECAKE FACTORY,71.4,debit,Dining,Restaurant,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,56.78,debit,Shopping,Online Retail,
+bofa-credit-card.csv,UBER EATS,29.3,debit,Dining,Food Delivery,
+bofa-credit-card.csv,PAYMENT THANK YOU,1200,credit,Transfer,Transfer,
+bofa-credit-card.csv,TARGET STORE 00024831,103.44,debit,Shopping,Department Store,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,DOORDASH*DOORDASH,24.8,debit,Dining,Food Delivery,
+bofa-credit-card.csv,TRADER JOES #123,68.2,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,CVS PHARMACY,18.75,debit,Health,Pharmacy,
+bofa-credit-card.csv,STARBUCKS STORE 08432,7.5,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,MCDONALDS #4821,9.25,debit,Dining,Fast Food,
+bofa-credit-card.csv,WHOLEFDS MKT #10,91.22,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,SHELL SERVICE STATION,66.8,debit,Transport,Gas Station,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,78.99,debit,Shopping,Online Retail,
+bofa-credit-card.csv,CHIPOTLE MEXICAN,13.45,debit,Dining,Fast Food,
+bofa-credit-card.csv,LYFT *RIDE,16.8,debit,Transport,Rideshare,
+bofa-credit-card.csv,PAYMENT THANK YOU,1400,credit,Transfer,Transfer,
+bofa-credit-card.csv,TRADER JOES #123,75.6,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,TARGET STORE 00024831,65.44,debit,Shopping,Department Store,
+bofa-credit-card.csv,DOORDASH*DOORDASH,31.5,debit,Dining,Food Delivery,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,STARBUCKS STORE 08432,8.25,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,APPLE.COM/BILL,2.99,debit,Subscriptions,Software/SaaS,
+bofa-credit-card.csv,COSTCO GAS #0472,61.4,debit,Transport,Gas Station,
+bofa-credit-card.csv,WHOLEFDS MKT #10,88.75,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,COSTCO GAS #0472,67.2,debit,Transport,Gas Station,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,44.33,debit,Shopping,Online Retail,
+bofa-credit-card.csv,SWEETGREEN,16.8,debit,Dining,Fast Food,
+bofa-credit-card.csv,LYFT *RIDE,14.5,debit,Transport,Rideshare,
+bofa-credit-card.csv,PAYMENT THANK YOU,1350,credit,Transfer,Transfer,
+bofa-credit-card.csv,TRADER JOES #123,71.3,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,UBER EATS,33.4,debit,Dining,Food Delivery,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,TARGET STORE 00024831,78.55,debit,Shopping,Department Store,
+bofa-credit-card.csv,STARBUCKS STORE 08432,7.75,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,CVS PHARMACY,24.9,debit,Health,Pharmacy,
+bofa-credit-card.csv,DOORDASH*DOORDASH,22.8,debit,Dining,Food Delivery,
+bofa-credit-card.csv,WHOLEFDS MKT #10,96.4,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,SHELL SERVICE STATION,74.8,debit,Transport,Gas Station,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,89.44,debit,Shopping,Online Retail,
+bofa-credit-card.csv,CHIPOTLE MEXICAN,15.2,debit,Dining,Fast Food,
+bofa-credit-card.csv,COSTCO GAS #0472,68.3,debit,Transport,Gas Station,
+bofa-credit-card.csv,PAYMENT THANK YOU,1300,credit,Transfer,Transfer,
+bofa-credit-card.csv,TRADER JOES #123,74.8,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,TOTAL WINE AND MORE,52.4,debit,Entertainment,Nightlife,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,TARGET STORE 00024831,71.22,debit,Shopping,Department Store,
+bofa-credit-card.csv,STARBUCKS STORE 08432,8,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,UBER EATS,29.9,debit,Dining,Food Delivery,
+bofa-credit-card.csv,CVS PHARMACY,19.4,debit,Health,Pharmacy,
+bofa-credit-card.csv,WHOLEFDS MKT #10,89.9,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,COSTCO GAS #0472,71.6,debit,Transport,Gas Station,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,127.5,debit,Shopping,Online Retail,
+bofa-credit-card.csv,SWEETGREEN,16.4,debit,Dining,Fast Food,
+bofa-credit-card.csv,LYFT *RIDE,18.2,debit,Transport,Rideshare,
+bofa-credit-card.csv,PAYMENT THANK YOU,1500,credit,Transfer,Transfer,
+bofa-credit-card.csv,TRADER JOES #123,77.3,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,CHEESECAKE FACTORY,84.6,debit,Dining,Restaurant,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,TARGET STORE 00024831,55.33,debit,Shopping,Department Store,
+bofa-credit-card.csv,STARBUCKS STORE 08432,8.75,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,CVS PHARMACY,21.8,debit,Health,Pharmacy,
+bofa-credit-card.csv,DOORDASH*DOORDASH,28.5,debit,Dining,Food Delivery,
+bofa-credit-card.csv,WHOLEFDS MKT #10,84.2,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,SHELL SERVICE STATION,68.4,debit,Transport,Gas Station,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,34.99,debit,Shopping,Online Retail,
+bofa-credit-card.csv,CHIPOTLE MEXICAN,14.8,debit,Dining,Fast Food,
+bofa-credit-card.csv,COSTCO GAS #0472,65.9,debit,Transport,Gas Station,
+bofa-credit-card.csv,PAYMENT THANK YOU,1400,credit,Transfer,Transfer,
+bofa-credit-card.csv,TRADER JOES #123,69.8,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,COSTCO WHSE #0472,168.44,debit,Groceries,Warehouse Club,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,TARGET STORE 00024831,82.55,debit,Shopping,Department Store,
+bofa-credit-card.csv,STARBUCKS STORE 08432,7.5,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,CVS PHARMACY,28.9,debit,Health,Pharmacy,
+bofa-credit-card.csv,DOORDASH*DOORDASH,24.8,debit,Dining,Food Delivery,
+bofa-credit-card.csv,WHOLEFDS MKT #10,92.3,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,COSTCO GAS #0472,73.2,debit,Transport,Gas Station,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,67.44,debit,Shopping,Online Retail,
+bofa-credit-card.csv,CHIPOTLE MEXICAN,15.3,debit,Dining,Fast Food,
+bofa-credit-card.csv,LYFT *RIDE,21.4,debit,Transport,Rideshare,
+bofa-credit-card.csv,PAYMENT THANK YOU,1350,credit,Transfer,Transfer,
+bofa-credit-card.csv,TRADER JOES #123,82.6,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,TARGET STORE 00024831,98.44,debit,Shopping,Department Store,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,STARBUCKS STORE 08432,8.25,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,CVS PHARMACY,42.18,debit,Health,Pharmacy,
+bofa-credit-card.csv,DOORDASH*DOORDASH,31.2,debit,Dining,Food Delivery,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,88.99,debit,Shopping,Online Retail,
+bofa-credit-card.csv,WHOLEFDS MKT #10,118.4,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,SHELL SERVICE STATION,72.8,debit,Transport,Gas Station,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,156.78,debit,Shopping,Online Retail,
+bofa-credit-card.csv,CHIPOTLE MEXICAN,15.9,debit,Dining,Fast Food,
+bofa-credit-card.csv,LYFT *RIDE,19.5,debit,Transport,Rideshare,
+bofa-credit-card.csv,PAYMENT THANK YOU,1600,credit,Transfer,Transfer,
+bofa-credit-card.csv,TRADER JOES #123,91.3,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,TARGET STORE 00024831,224.88,debit,Shopping,Department Store,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,STARBUCKS STORE 08432,9.25,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,CVS PHARMACY,35.8,debit,Health,Pharmacy,
+bofa-credit-card.csv,DOORDASH*DOORDASH,38.5,debit,Dining,Food Delivery,
+bofa-credit-card.csv,BEST BUY 00287,179.99,debit,Shopping,Electronics,
+bofa-credit-card.csv,WHOLEFDS MKT #10,122.5,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,COSTCO GAS #0472,70.3,debit,Transport,Gas Station,
+bofa-credit-card.csv,AMAZON MKTPLACE PMTS,287.44,debit,Shopping,Online Retail,
+bofa-credit-card.csv,CHIPOTLE MEXICAN,16.8,debit,Dining,Fast Food,
+bofa-credit-card.csv,LYFT *RIDE,24.8,debit,Transport,Rideshare,
+bofa-credit-card.csv,PAYMENT THANK YOU,1800,credit,Transfer,Transfer,
+bofa-credit-card.csv,TRADER JOES #123,98.4,debit,Groceries,Specialty Food,
+bofa-credit-card.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,
+bofa-credit-card.csv,TARGET STORE 00024831,144.55,debit,Shopping,Department Store,
+bofa-credit-card.csv,GYM MEMBERSHIP,44.99,debit,Health,Gym,
+bofa-credit-card.csv,STARBUCKS STORE 08432,11.5,debit,Dining,Coffee Shop,
+bofa-credit-card.csv,CVS PHARMACY,28.9,debit,Health,Pharmacy,
+bofa-credit-card.csv,DOORDASH*DOORDASH,34.8,debit,Dining,Food Delivery,
+bofa-credit-card.csv,BEST BUY 00287,229.99,debit,Shopping,Electronics,
+bofa-credit-card.csv,DELTA AIR LINES TICKET,389,debit,Travel,Flight,
+bofa-credit-card.csv,MARRIOTT SAN JOSE CONF CTR,312,debit,Travel,Hotel,
+bofa-credit-card.csv,OAK & VINE RESTAURANT,94.5,debit,Dining,Restaurant,
+bofa-credit-card.csv,AMAZON.COM OFFICE SUPPLIES,67.89,debit,Shopping,Online Retail,
+bofa-credit-card.csv,ASPEN DENTAL ASSOCIATES,425,debit,Health,Dentist,
+bofa-credit-card.csv,DELTA AIR LINES TICKET,445,debit,Travel,Flight,
+bofa-credit-card.csv,HILTON GARDEN INN,289,debit,Travel,Hotel,
+bofa-credit-card.csv,MARKET BISTRO RESTAURANT,112.4,debit,Dining,Restaurant,
+bofa-credit-card.csv,AMAZON.COM*9XM2K1PR,58.44,debit,Shopping,Online Retail,
+bofa-credit-card.csv,DR SARAH CHEN MD OFFICE,250,debit,Health,Doctor/Medical,
+bofa-credit-card.csv,GITHUB INC,100,debit,Subscriptions,Software/SaaS,
+bofa-credit-card.csv,VISION SOURCE EYE CARE,195,debit,Health,Vision,
+bofa-credit-card.csv,DELTA AIR LINES TICKET,512,debit,Travel,Flight,
+bofa-credit-card.csv,WESTIN HOTEL,398,debit,Travel,Hotel,
+bofa-credit-card.csv,TASTE OF ITALY RISTORANTE,87.6,debit,Dining,Restaurant,
+bofa-credit-card.csv,AMAZON.COM*4PT8N2VX,142.33,debit,Shopping,Online Retail,
+bofa-credit-card.csv,NOTION LABS INC,96,debit,Subscriptions,Software/SaaS,
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,87.43,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,68.2,debit,Transport,Gas Station,Gas
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,AMAZON.COM*2K7LM9PQ4,42.99,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,UBER* TRIP,14.75,debit,Transport,Rideshare,Travel
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,CVS PHARMACY #7824,23.58,debit,Health,Pharmacy,Health & Wellness
+chase-checking.csv,STARBUCKS #08432,6.75,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,PG&E ELECTRIC BILL,142.18,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,TRADER JOE S #123,63.41,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,AMZN MKTP US*3R9KP REFUND,18,credit,Shopping,Online Retail,Shopping
+chase-checking.csv,CHIPOTLE MEXICAN GRILL,12.85,debit,Dining,Fast Food,Food & Drink
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,INTEREST PAYMENT,4.21,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,91.17,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,72.4,debit,Transport,Gas Station,Gas
+chase-checking.csv,HULU,17.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,AMAZON.COM*9X2MN5TR8,134,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,LYFT *RIDE MON 5PM,11.5,debit,Transport,Rideshare,Travel
+chase-checking.csv,VALENTIN RESTAURANT,98,debit,Dining,Restaurant,Food & Drink
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,TARGET 00024831,57.32,debit,Shopping,Department Store,Shopping
+chase-checking.csv,CHEESECAKE FACTORY,78.9,debit,Dining,Restaurant,Food & Drink
+chase-checking.csv,PG&E ELECTRIC BILL,138.55,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,TRADER JOE S #123,55.88,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,CVS PHARMACY #7824,14.29,debit,Health,Pharmacy,Health & Wellness
+chase-checking.csv,INTEREST PAYMENT,4.35,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,79.65,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,AMAZON.COM*7K4JL2QP1,29.99,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,UBER EATS,34.2,debit,Dining,Food Delivery,Food & Drink
+chase-checking.csv,STARBUCKS #08432,7.25,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,COSTCO WHSE #0472,187.43,debit,Groceries,Warehouse Club,Shopping
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,PG&E ELECTRIC BILL,138.55,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,TRADER JOE S #123,68.92,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,APPLE.COM/BILL,2.99,debit,Subscriptions,Software/SaaS,Entertainment
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,VENMO PAYMENT,80,debit,Transfer,Transfer,Transfer
+chase-checking.csv,INTEREST PAYMENT,4.18,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,82.33,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,69.9,debit,Transport,Gas Station,Gas
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,STATE TAX REFUND,812,credit,Income,Tax Refund,Tax
+chase-checking.csv,AMAZON.COM*3P8NX7YR2,56.78,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,STARBUCKS #08432,6.75,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,TRADER JOE S #123,61.2,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,PG&E ELECTRIC BILL,88.92,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,LYFT *RIDE,18.9,debit,Transport,Rideshare,Travel
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,WALGREENS STORE #4201,31.47,debit,Health,Pharmacy,Health & Wellness
+chase-checking.csv,INTEREST PAYMENT,4.42,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,94.67,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,67.9,debit,Transport,Gas Station,Gas
+chase-checking.csv,AMAZON.COM*5H2KL9MQ7,78.99,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,STARBUCKS #08432,7.5,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,TRADER JOE S #123,72.14,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,CHIPOTLE MEXICAN GRILL,14.2,debit,Dining,Fast Food,Food & Drink
+chase-checking.csv,PG&E ELECTRIC BILL,91.1,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,TARGET 00024831,67.44,debit,Shopping,Department Store,Shopping
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,TRADER JOE S #123,55.3,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,INTEREST PAYMENT,4.61,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,88.91,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,74.2,debit,Transport,Gas Station,Gas
+chase-checking.csv,AMAZON.COM PRIME MEMBERSHIP,139,debit,Subscriptions,Streaming,Shopping
+chase-checking.csv,STARBUCKS #08432,6.25,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,TRADER JOE S #123,65.77,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,AMAZON.COM*8Q3NV5WP1,45.33,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,PG&E ELECTRIC BILL,118.43,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,UBER EATS,28.5,debit,Dining,Food Delivery,Food & Drink
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,INTEREST PAYMENT,4.55,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,102.48,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,TOTAL WINE & MORE,48.75,debit,Entertainment,Nightlife,Food & Drink
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,AMAZON.COM*1L6PQ2TK9,33.47,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,71.6,debit,Transport,Gas Station,Gas
+chase-checking.csv,STARBUCKS #08432,7,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,TRADER JOE S #123,70.33,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,PG&E ELECTRIC BILL,158.92,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,TARGET 00024831,44.22,debit,Shopping,Department Store,Shopping
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,CVS PHARMACY #7824,22.4,debit,Health,Pharmacy,Health & Wellness
+chase-checking.csv,INTEREST PAYMENT,4.72,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,85.6,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,69.4,debit,Transport,Gas Station,Gas
+chase-checking.csv,AMAZON.COM*4R7MN8PQ3,127.5,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,STARBUCKS #08432,7.25,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,TRADER JOE S #123,75.44,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,CVS PHARMACY #7824,18.75,debit,Health,Pharmacy,Health & Wellness
+chase-checking.csv,UBER EATS,35.8,debit,Dining,Food Delivery,Food & Drink
+chase-checking.csv,PG&E ELECTRIC BILL,172.3,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,TRADER JOE S #123,62.1,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,CHIPOTLE MEXICAN GRILL,13.9,debit,Dining,Fast Food,Food & Drink
+chase-checking.csv,INTEREST PAYMENT,4.83,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,92.28,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,66.8,debit,Transport,Gas Station,Gas
+chase-checking.csv,AMAZON.COM*9W2PK5QR6,89.99,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,STARBUCKS #08432,7.75,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,TRADER JOE S #123,58.6,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,PG&E ELECTRIC BILL,118.75,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,COSTCO WHSE #0472,156.78,debit,Groceries,Warehouse Club,Shopping
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,WALGREENS STORE #4201,28.5,debit,Health,Pharmacy,Health & Wellness
+chase-checking.csv,INTEREST PAYMENT,5.1,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,89.4,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,73.3,debit,Transport,Gas Station,Gas
+chase-checking.csv,AMAZON.COM*6T4NM2KW8,67.44,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,STARBUCKS #08432,7.75,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,TRADER JOE S #123,77.22,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,CHIPOTLE MEXICAN GRILL,14.75,debit,Dining,Fast Food,Food & Drink
+chase-checking.csv,TARGET 00024831,88.55,debit,Shopping,Department Store,Shopping
+chase-checking.csv,PG&E ELECTRIC BILL,102.18,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,CVS PHARMACY #7824,42.18,debit,Health,Pharmacy,Health & Wellness
+chase-checking.csv,INTEREST PAYMENT,5.24,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,108.3,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,72.1,debit,Transport,Gas Station,Gas
+chase-checking.csv,AMAZON.COM*2P5KQ9TN4,156.78,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,STARBUCKS #08432,7.25,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,TRADER JOE S #123,88.4,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,CHIPOTLE MEXICAN GRILL,14.9,debit,Dining,Fast Food,Food & Drink
+chase-checking.csv,PG&E ELECTRIC BILL,121.44,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,TRADER JOE S #123,143.6,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,TARGET 00024831,224.88,debit,Shopping,Department Store,Shopping
+chase-checking.csv,INTEREST PAYMENT,5.35,credit,Income,Interest,Interest
+chase-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,Home
+chase-checking.csv,WHOLEFDS #10 MARKET ST,108.55,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,NETFLIX.COM,15.49,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,DIRECT DEPOSIT EMPLOYER PAYROLL,3500,credit,Income,Payroll,Payroll
+chase-checking.csv,YEAR END BONUS,1000,credit,Income,Bonus,Payroll
+chase-checking.csv,AMAZON.COM*8N3LQ7PK5,287.44,debit,Shopping,Online Retail,Shopping
+chase-checking.csv,SHELL OIL 57442 SAN FRANCISCO CA,70.8,debit,Transport,Gas Station,Gas
+chase-checking.csv,STARBUCKS #08432,9.5,debit,Dining,Coffee Shop,Food & Drink
+chase-checking.csv,TRADER JOE S #123,95.2,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,SPOTIFY USA,9.99,debit,Subscriptions,Streaming,Entertainment
+chase-checking.csv,ONLINE TRANSFER TO SAV ...4821,500,debit,Transfer,Transfer,Transfer
+chase-checking.csv,CHIPOTLE MEXICAN GRILL,16.4,debit,Dining,Fast Food,Food & Drink
+chase-checking.csv,PG&E ELECTRIC BILL,145.33,debit,Housing,Utilities,Bills & Utilities
+chase-checking.csv,PLANET FITNESS 0032,24.99,debit,Health,Gym,Health & Wellness
+chase-checking.csv,WHOLEFDS #10 MARKET ST,178.4,debit,Groceries,Specialty Food,Food & Drink
+chase-checking.csv,AT&T *PAYMENT,89,debit,Housing,Phone Bill,Bills & Utilities
+chase-checking.csv,TARGET 00024831,112.33,debit,Shopping,Department Store,Shopping
+chase-checking.csv,INTEREST PAYMENT,5.48,credit,Income,Interest,Interest
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance,Income
+chase-checking.csv,CHARITY WATER DONATION,50,debit,Other,Donation,Charity
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance,Income
+chase-checking.csv,AMERICAN RED CROSS DONATION,100,debit,Other,Donation,Charity
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance,Income
+chase-checking.csv,COUNTY PROPERTY TAX PAYMENT,2200,debit,Other,Property Tax,Tax
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,2200,credit,Income,Freelance,Income
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance,Income
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance,Income
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1800,credit,Income,Freelance,Income
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance,Income
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance,Income
+chase-checking.csv,COUNTY PROPERTY TAX PAYMENT,2200,debit,Other,Property Tax,Tax
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance,Income
+chase-checking.csv,CHARITY WATER DONATION,50,debit,Other,Donation,Charity
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,2000,credit,Income,Freelance,Income
+chase-checking.csv,DOCTORS MEDICAL GROUP,180,debit,Health,Doctor/Medical,Medical
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+chase-checking.csv,ACH CREDIT DESIGNCO CLIENT PAYMENT,1500,credit,Income,Freelance,Income
+chase-checking.csv,AMERICAN RED CROSS DONATION,150,debit,Other,Donation,Charity
+chase-checking.csv,BRIGHT HORIZONS CHILDCARE,950,debit,Childcare,Daycare,Childcare
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,87.43,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,68.2,debit,Transport,Gas Station,
+credit-union-checking.csv,AMAZON.COM,42.99,debit,Shopping,Online Retail,
+credit-union-checking.csv,UBER TRIP,14.75,debit,Transport,Rideshare,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,CVS PHARMACY,23.58,debit,Health,Pharmacy,
+credit-union-checking.csv,STARBUCKS,6.75,debit,Dining,Coffee Shop,
+credit-union-checking.csv,PG&E,142.18,debit,Housing,Utilities,
+credit-union-checking.csv,TRADER JOES,63.41,debit,Groceries,Specialty Food,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,AMAZON REFUND,18,credit,Shopping,Online Retail,
+credit-union-checking.csv,CHIPOTLE,12.85,debit,Dining,Fast Food,
+credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill,
+credit-union-checking.csv,INTEREST EARNED,4.21,credit,Income,Interest,
+credit-union-checking.csv,RENTER INSURANCE ALLSTATE,125,debit,Housing,Insurance,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,91.17,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,72.4,debit,Transport,Gas Station,
+credit-union-checking.csv,HULU,17.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,AMAZON.COM,134,debit,Shopping,Online Retail,
+credit-union-checking.csv,LYFT,11.5,debit,Transport,Rideshare,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,TARGET,57.32,debit,Shopping,Department Store,
+credit-union-checking.csv,CHEESECAKE FACTORY,78.9,debit,Dining,Restaurant,
+credit-union-checking.csv,COMCAST,109.99,debit,Housing,Internet/Cable,
+credit-union-checking.csv,TRADER JOES,55.88,debit,Groceries,Specialty Food,
+credit-union-checking.csv,ZELLE PAYMENT TO ALEX,650,debit,Transfer,Transfer,
+credit-union-checking.csv,CVS PHARMACY,14.29,debit,Health,Pharmacy,
+credit-union-checking.csv,DOORDASH,9.99,debit,Dining,Food Delivery,
+credit-union-checking.csv,INTEREST EARNED,3.98,credit,Income,Interest,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,79.65,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,68.8,debit,Transport,Gas Station,
+credit-union-checking.csv,AMAZON.COM,29.99,debit,Shopping,Online Retail,
+credit-union-checking.csv,UBER EATS,34.2,debit,Dining,Food Delivery,
+credit-union-checking.csv,STARBUCKS,7.25,debit,Dining,Coffee Shop,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,COSTCO,187.43,debit,Groceries,Warehouse Club,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,PG&E,138.55,debit,Housing,Utilities,
+credit-union-checking.csv,TRADER JOES,68.92,debit,Groceries,Specialty Food,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,APPLE.COM/BILL,2.99,debit,Subscriptions,Software/SaaS,
+credit-union-checking.csv,SIDE JOB PAYMENT,850,credit,Income,Side Income,
+credit-union-checking.csv,INTEREST EARNED,4.44,credit,Income,Interest,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,82.33,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,67.8,debit,Transport,Gas Station,
+credit-union-checking.csv,AMAZON.COM,44.99,debit,Shopping,Online Retail,
+credit-union-checking.csv,STARBUCKS,6.75,debit,Dining,Coffee Shop,
+credit-union-checking.csv,TRADER JOES,65.2,debit,Groceries,Specialty Food,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,CHIPOTLE,14.4,debit,Dining,Fast Food,
+credit-union-checking.csv,PG&E,82.44,debit,Housing,Utilities,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill,
+credit-union-checking.csv,WALGREENS,31.47,debit,Health,Pharmacy,
+credit-union-checking.csv,LYFT,12.5,debit,Transport,Rideshare,
+credit-union-checking.csv,INTEREST EARNED,4.35,credit,Income,Interest,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,88.4,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,67.2,debit,Transport,Gas Station,
+credit-union-checking.csv,AMAZON.COM,44.99,debit,Shopping,Online Retail,
+credit-union-checking.csv,STARBUCKS,7.25,debit,Dining,Coffee Shop,
+credit-union-checking.csv,TRADER JOES,72.15,debit,Groceries,Specialty Food,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,UBER EATS,32.5,debit,Dining,Food Delivery,
+credit-union-checking.csv,PG&E,91.1,debit,Housing,Utilities,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,TARGET,78.44,debit,Shopping,Department Store,
+credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill,
+credit-union-checking.csv,TRADER JOES,55.3,debit,Groceries,Specialty Food,
+credit-union-checking.csv,INTEREST EARNED,4.52,credit,Income,Interest,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,90.15,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,73.4,debit,Transport,Gas Station,
+credit-union-checking.csv,AMAZON.COM,38.99,debit,Shopping,Online Retail,
+credit-union-checking.csv,STARBUCKS,6.5,debit,Dining,Coffee Shop,
+credit-union-checking.csv,TRADER JOES,68.3,debit,Groceries,Specialty Food,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,SIDE JOB PAYMENT,950,credit,Income,Side Income,
+credit-union-checking.csv,CHIPOTLE,15.2,debit,Dining,Fast Food,
+credit-union-checking.csv,PG&E,118.43,debit,Housing,Utilities,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,LYFT,16.8,debit,Transport,Rideshare,
+credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill,
+credit-union-checking.csv,UBER EATS,27.4,debit,Dining,Food Delivery,
+credit-union-checking.csv,INTEREST EARNED,4.68,credit,Income,Interest,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,95.5,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,75.2,debit,Transport,Gas Station,
+credit-union-checking.csv,AMAZON.COM,89.44,debit,Shopping,Online Retail,
+credit-union-checking.csv,STARBUCKS,7,debit,Dining,Coffee Shop,
+credit-union-checking.csv,TRADER JOES,71.88,debit,Groceries,Specialty Food,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,CHIPOTLE,14.85,debit,Dining,Fast Food,
+credit-union-checking.csv,PG&E,158.92,debit,Housing,Utilities,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,TARGET,66.33,debit,Shopping,Department Store,
+credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill,
+credit-union-checking.csv,CVS PHARMACY,22.4,debit,Health,Pharmacy,
+credit-union-checking.csv,INTEREST EARNED,4.77,credit,Income,Interest,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,88.9,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,71.3,debit,Transport,Gas Station,
+credit-union-checking.csv,AMAZON.COM,145,debit,Shopping,Online Retail,
+credit-union-checking.csv,STARBUCKS,7.25,debit,Dining,Coffee Shop,
+credit-union-checking.csv,TRADER JOES,75.44,debit,Groceries,Specialty Food,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,UBER EATS,35.8,debit,Dining,Food Delivery,
+credit-union-checking.csv,PG&E,172.3,debit,Housing,Utilities,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,TRADER JOES,62.1,debit,Groceries,Specialty Food,
+credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill,
+credit-union-checking.csv,STARBUCKS,8.5,debit,Dining,Coffee Shop,
+credit-union-checking.csv,INTEREST EARNED,4.93,credit,Income,Interest,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,83.2,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,67.8,debit,Transport,Gas Station,
+credit-union-checking.csv,SIDE JOB PAYMENT,925,credit,Income,Side Income,
+credit-union-checking.csv,AMAZON.COM,34.99,debit,Shopping,Online Retail,
+credit-union-checking.csv,STARBUCKS,7.5,debit,Dining,Coffee Shop,
+credit-union-checking.csv,TRADER JOES,58.66,debit,Groceries,Specialty Food,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,CHIPOTLE,15.4,debit,Dining,Fast Food,
+credit-union-checking.csv,PG&E,135.75,debit,Housing,Utilities,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,COSTCO WHSE,178.33,debit,Groceries,Warehouse Club,
+credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill,
+credit-union-checking.csv,CVS PHARMACY,28.5,debit,Health,Pharmacy,
+credit-union-checking.csv,INTEREST EARNED,5.1,credit,Income,Interest,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,90.45,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,73.9,debit,Transport,Gas Station,
+credit-union-checking.csv,AMAZON.COM,67.44,debit,Shopping,Online Retail,
+credit-union-checking.csv,STARBUCKS,7.75,debit,Dining,Coffee Shop,
+credit-union-checking.csv,TRADER JOES,80.22,debit,Groceries,Specialty Food,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,TARGET,88.55,debit,Shopping,Department Store,
+credit-union-checking.csv,PG&E,102.18,debit,Housing,Utilities,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,LYFT,19.2,debit,Transport,Rideshare,
+credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill,
+credit-union-checking.csv,CVS PHARMACY,42.18,debit,Health,Pharmacy,
+credit-union-checking.csv,INTEREST EARNED,5.24,credit,Income,Interest,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,108.3,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,72.1,debit,Transport,Gas Station,
+credit-union-checking.csv,AMAZON.COM,156.78,debit,Shopping,Online Retail,
+credit-union-checking.csv,STARBUCKS,7.25,debit,Dining,Coffee Shop,
+credit-union-checking.csv,TRADER JOES,88.4,debit,Groceries,Specialty Food,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,CHIPOTLE,14.9,debit,Dining,Fast Food,
+credit-union-checking.csv,PG&E,121.44,debit,Housing,Utilities,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill,
+credit-union-checking.csv,TRADER JOES,143.6,debit,Groceries,Specialty Food,
+credit-union-checking.csv,TARGET,224.88,debit,Shopping,Department Store,
+credit-union-checking.csv,INTEREST EARNED,5.35,credit,Income,Interest,
+credit-union-checking.csv,RENT PAYMENT - OAKWOOD APTS,1850,debit,Housing,Rent,
+credit-union-checking.csv,PAYROLL DIRECT DEPOSIT ACME CORP,3500,credit,Income,Payroll,
+credit-union-checking.csv,WHOLEFDS MARKET,112.5,debit,Groceries,Specialty Food,
+credit-union-checking.csv,NETFLIX,15.49,debit,Subscriptions,Streaming,
+credit-union-checking.csv,SHELL OIL 57442,70.8,debit,Transport,Gas Station,
+credit-union-checking.csv,AMAZON.COM,287.44,debit,Shopping,Online Retail,
+credit-union-checking.csv,STARBUCKS,9.5,debit,Dining,Coffee Shop,
+credit-union-checking.csv,SIDE JOB PAYMENT,875,credit,Income,Side Income,
+credit-union-checking.csv,TRADER JOES,95.2,debit,Groceries,Specialty Food,
+credit-union-checking.csv,SPOTIFY,9.99,debit,Subscriptions,Streaming,
+credit-union-checking.csv,TRANSFER TO SAVINGS,500,debit,Transfer,Transfer,
+credit-union-checking.csv,CHIPOTLE,16.4,debit,Dining,Fast Food,
+credit-union-checking.csv,PG&E,145.33,debit,Housing,Utilities,
+credit-union-checking.csv,PLANET FITNESS,24.99,debit,Health,Gym,
+credit-union-checking.csv,WHOLEFDS MARKET,178.4,debit,Groceries,Specialty Food,
+credit-union-checking.csv,AT&T WIRELESS,89,debit,Housing,Phone Bill,
+credit-union-checking.csv,TARGET,144.55,debit,Shopping,Department Store,
+credit-union-checking.csv,INTEREST EARNED,5.48,credit,Income,Interest,
+monzo-uk.csv,Tesco Express,12.45,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,6.8,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Deliveroo,22.9,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Amazon,34.99,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Sainsbury's,45.32,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Costa Coffee,4.5,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Shell,58.4,debit,Transport,Gas Station,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,M&S Food,28.75,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Monzo Flex,250,debit,Transfer,Transfer,Transfers
+monzo-uk.csv,Tesco Express,14.9,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Amazon,67.5,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Sainsbury's,52.18,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Deliveroo,19.5,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Costa Coffee,4.75,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,M&S Food,31.4,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,Restaurant 1847,88,debit,Dining,Restaurant,Eating out
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Tesco,61.22,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Amazon,22,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Tesco Express,16.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Deliveroo,21.8,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Costa Coffee,5.25,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Sainsbury's,45.2,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent,Housing
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Tesco Express,14.9,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,6.8,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Deliveroo,22.5,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Amazon,34.99,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Costa Coffee,4.75,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Sainsbury's,52.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,M&S Food,31.4,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Tesco,61.22,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Deliveroo,19.5,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Amazon,22,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Uber Eats,18.9,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Costa Coffee,5.25,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent,Housing
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Tesco Express,12.45,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,6.5,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Sainsbury's,48.3,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Amazon,67.5,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Costa Coffee,4.5,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,M&S Food,28.75,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Deliveroo,24.8,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Tesco,55.3,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Uber Eats,21.5,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Restaurant 1847,88,debit,Dining,Restaurant,Eating out
+monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent,Housing
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Tesco Express,14.9,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,7.2,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Amazon,44.99,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Sainsbury's,52.18,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Costa Coffee,5,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,M&S Food,33.6,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Deliveroo,19.5,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Tesco,48.2,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,6.8,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Amazon,29.99,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent,Housing
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Tesco Express,13.6,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,6.25,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Sainsbury's,55.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Costa Coffee,4.75,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,Deliveroo,28.4,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Tesco,62.1,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Amazon,34.99,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Restaurant,65,debit,Dining,Restaurant,Eating out
+monzo-uk.csv,M&S Food,41.8,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent,Housing
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Tesco Express,12.45,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,6.8,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Amazon,89.99,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Sainsbury's,47.3,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Costa Coffee,5.25,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,M&S Food,35.6,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Deliveroo,31.5,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Tesco,58.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Amazon,22,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Restaurant,78.5,debit,Dining,Restaurant,Eating out
+monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent,Housing
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Tesco Express,15.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,7,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Amazon,145,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Sainsbury's,61.3,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Costa Coffee,4.5,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,M&S Food,38.9,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Deliveroo,25.8,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Tesco,53.2,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Amazon,67.5,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Pret A Manger,6.75,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent,Housing
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Tesco Express,13.85,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,6.5,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Sainsbury's,54.8,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Costa Coffee,5,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,Amazon,44.99,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,M&S Food,32.4,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Deliveroo,22.9,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Tesco,69.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Uber Eats,18.5,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Amazon,38.99,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent,Housing
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Tesco Express,14.9,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,6.8,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Amazon,78.99,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Sainsbury's,58.2,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Costa Coffee,5.5,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,M&S Food,41.6,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Deliveroo,33.5,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Tesco,71.2,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Amazon,55,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Uber Eats,24.8,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent,Housing
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Tesco Express,16.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,7.5,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Amazon,245,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Sainsbury's,78.5,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Costa Coffee,5.25,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,M&S Food,55.8,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Deliveroo,38.5,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Tesco,91.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Amazon,189.99,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Marks & Spencer,120,debit,Shopping,Clothing,Shopping
+monzo-uk.csv,Pret A Manger,8.25,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,RENT - LANDLORD,1200,debit,Housing,Rent,Housing
+monzo-uk.csv,EMPLOYER SALARY,2800,credit,Income,Payroll,Income
+monzo-uk.csv,Tesco Express,18.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Pret A Manger,8.5,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Amazon,312,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Sainsbury's,102.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Netflix,10.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Spotify,9.99,debit,Subscriptions,Streaming,Entertainment
+monzo-uk.csv,Costa Coffee,6,debit,Dining,Coffee Shop,Eating out
+monzo-uk.csv,Oyster / TfL,34.1,debit,Transport,Public Transit,Transport
+monzo-uk.csv,Gym Membership,40,debit,Health,Gym,Health
+monzo-uk.csv,M&S Food,88.5,debit,Groceries,Specialty Food,Groceries
+monzo-uk.csv,Deliveroo,45.8,debit,Dining,Food Delivery,Eating out
+monzo-uk.csv,Tesco,125.4,debit,Groceries,Supermarket,Groceries
+monzo-uk.csv,Amazon,178,debit,Shopping,Online Retail,Shopping
+monzo-uk.csv,Restaurant,195,debit,Dining,Restaurant,Eating out
+monzo-uk.csv,Pret A Manger,7.75,debit,Dining,Coffee Shop,Eating out

--- a/sample-data/labeled/messy-variants.csv
+++ b/sample-data/labeled/messy-variants.csv
@@ -1,321 +1,321 @@
-sourceFile,description,amount,type,category,subcategory
-messy-variants.csv,STARBUCKS #1024,25,debit,Dining,Coffee Shop
-messy-variants.csv,STARBUCKS SAN LUIS OBISPO CA,25,debit,Dining,Coffee Shop
-messy-variants.csv,POS DEBIT SQ *STARBUCKS,25,debit,Dining,Coffee Shop
-messy-variants.csv,SQ *STARBUCKS #1024,25,debit,Dining,Coffee Shop
-messy-variants.csv,BLUE BOTTLE COFFEE #5578,25,debit,Dining,Coffee Shop
-messy-variants.csv,BLUE BOTTLE COFFEE AUSTIN TX,25,debit,Dining,Coffee Shop
-messy-variants.csv,RECURRING PAYMENT TST* BLUE BOTTLE COFFEE,25,debit,Dining,Coffee Shop
-messy-variants.csv,TST* BLUE BOTTLE COFFEE #5578,25,debit,Dining,Coffee Shop
-messy-variants.csv,DUNKIN #219,25,debit,Dining,Coffee Shop
-messy-variants.csv,DUNKIN BROOKLYN NY,25,debit,Dining,Coffee Shop
-messy-variants.csv,CHECKCARD PAYPAL *DUNKIN,25,debit,Dining,Coffee Shop
-messy-variants.csv,PAYPAL *DUNKIN #219,25,debit,Dining,Coffee Shop
-messy-variants.csv,MCDONALDS #8842,25,debit,Dining,Fast Food
-messy-variants.csv,MCDONALDS PORTLAND OR,25,debit,Dining,Fast Food
-messy-variants.csv,DEBIT CARD PURCHASE SP *MCDONALDS,25,debit,Dining,Fast Food
-messy-variants.csv,SP *MCDONALDS #8842,25,debit,Dining,Fast Food
-messy-variants.csv,CHIPOTLE #33,25,debit,Dining,Fast Food
-messy-variants.csv,CHIPOTLE DENVER CO,25,debit,Dining,Fast Food
-messy-variants.csv,POS DEBIT SQ *CHIPOTLE,25,debit,Dining,Fast Food
-messy-variants.csv,SQ *CHIPOTLE #33,25,debit,Dining,Fast Food
-messy-variants.csv,CHICK-FIL-A #7701,25,debit,Dining,Fast Food
-messy-variants.csv,CHICK-FIL-A MIAMI FL,25,debit,Dining,Fast Food
-messy-variants.csv,RECURRING PAYMENT TST* CHICK-FIL-A,25,debit,Dining,Fast Food
-messy-variants.csv,TST* CHICK-FIL-A #7701,25,debit,Dining,Fast Food
-messy-variants.csv,FIVE GUYS #456,25,debit,Dining,Fast Food
-messy-variants.csv,FIVE GUYS SEATTLE WA,25,debit,Dining,Fast Food
-messy-variants.csv,CHECKCARD PAYPAL *FIVE GUYS,25,debit,Dining,Fast Food
-messy-variants.csv,PAYPAL *FIVE GUYS #456,25,debit,Dining,Fast Food
-messy-variants.csv,OLIVE GARDEN #9012,25,debit,Dining,Restaurant
-messy-variants.csv,OLIVE GARDEN CHICAGO IL,25,debit,Dining,Restaurant
-messy-variants.csv,DEBIT CARD PURCHASE SP *OLIVE GARDEN,25,debit,Dining,Restaurant
-messy-variants.csv,SP *OLIVE GARDEN #9012,25,debit,Dining,Restaurant
-messy-variants.csv,DOORDASH #214,25,debit,Dining,Food Delivery
-messy-variants.csv,DOORDASH PHOENIX AZ,25,debit,Dining,Food Delivery
-messy-variants.csv,POS DEBIT SQ *DOORDASH,25,debit,Dining,Food Delivery
-messy-variants.csv,SQ *DOORDASH #214,25,debit,Dining,Food Delivery
-messy-variants.csv,GRUBHUB #6689,25,debit,Dining,Food Delivery
-messy-variants.csv,GRUBHUB BOSTON MA,25,debit,Dining,Food Delivery
-messy-variants.csv,RECURRING PAYMENT TST* GRUBHUB,25,debit,Dining,Food Delivery
-messy-variants.csv,TST* GRUBHUB #6689,25,debit,Dining,Food Delivery
-messy-variants.csv,WHOLE FOODS MARKET #1024,25,debit,Groceries,Specialty Food
-messy-variants.csv,WHOLE FOODS MARKET SAN LUIS OBISPO CA,25,debit,Groceries,Specialty Food
-messy-variants.csv,CHECKCARD PAYPAL *WHOLE FOODS MARKET,25,debit,Groceries,Specialty Food
-messy-variants.csv,PAYPAL *WHOLE FOODS MARKET #1024,25,debit,Groceries,Specialty Food
-messy-variants.csv,TRADER JOES #5578,25,debit,Groceries,Specialty Food
-messy-variants.csv,TRADER JOES AUSTIN TX,25,debit,Groceries,Specialty Food
-messy-variants.csv,DEBIT CARD PURCHASE SP *TRADER JOES,25,debit,Groceries,Specialty Food
-messy-variants.csv,SP *TRADER JOES #5578,25,debit,Groceries,Specialty Food
-messy-variants.csv,KROGER #219,25,debit,Groceries,Supermarket
-messy-variants.csv,KROGER BROOKLYN NY,25,debit,Groceries,Supermarket
-messy-variants.csv,POS DEBIT SQ *KROGER,25,debit,Groceries,Supermarket
-messy-variants.csv,SQ *KROGER #219,25,debit,Groceries,Supermarket
-messy-variants.csv,SAFEWAY #8842,25,debit,Groceries,Supermarket
-messy-variants.csv,SAFEWAY PORTLAND OR,25,debit,Groceries,Supermarket
-messy-variants.csv,RECURRING PAYMENT TST* SAFEWAY,25,debit,Groceries,Supermarket
-messy-variants.csv,TST* SAFEWAY #8842,25,debit,Groceries,Supermarket
-messy-variants.csv,COSTCO WHSE #33,25,debit,Groceries,Warehouse Club
-messy-variants.csv,COSTCO WHSE DENVER CO,25,debit,Groceries,Warehouse Club
-messy-variants.csv,CHECKCARD PAYPAL *COSTCO WHSE,25,debit,Groceries,Warehouse Club
-messy-variants.csv,PAYPAL *COSTCO WHSE #33,25,debit,Groceries,Warehouse Club
-messy-variants.csv,INSTACART #7701,25,debit,Groceries,Grocery Delivery
-messy-variants.csv,INSTACART MIAMI FL,25,debit,Groceries,Grocery Delivery
-messy-variants.csv,DEBIT CARD PURCHASE SP *INSTACART,25,debit,Groceries,Grocery Delivery
-messy-variants.csv,SP *INSTACART #7701,25,debit,Groceries,Grocery Delivery
-messy-variants.csv,TESCO #456,25,debit,Groceries,Supermarket
-messy-variants.csv,TESCO SEATTLE WA,25,debit,Groceries,Supermarket
-messy-variants.csv,POS DEBIT SQ *TESCO,25,debit,Groceries,Supermarket
-messy-variants.csv,SQ *TESCO #456,25,debit,Groceries,Supermarket
-messy-variants.csv,SAINSBURY'S #9012,25,debit,Groceries,Supermarket
-messy-variants.csv,SAINSBURY'S CHICAGO IL,25,debit,Groceries,Supermarket
-messy-variants.csv,RECURRING PAYMENT TST* SAINSBURY'S,25,debit,Groceries,Supermarket
-messy-variants.csv,TST* SAINSBURY'S #9012,25,debit,Groceries,Supermarket
-messy-variants.csv,SHELL OIL #214,25,debit,Transport,Gas Station
-messy-variants.csv,SHELL OIL PHOENIX AZ,25,debit,Transport,Gas Station
-messy-variants.csv,CHECKCARD PAYPAL *SHELL OIL,25,debit,Transport,Gas Station
-messy-variants.csv,PAYPAL *SHELL OIL #214,25,debit,Transport,Gas Station
-messy-variants.csv,CHEVRON #6689,25,debit,Transport,Gas Station
-messy-variants.csv,CHEVRON BOSTON MA,25,debit,Transport,Gas Station
-messy-variants.csv,DEBIT CARD PURCHASE SP *CHEVRON,25,debit,Transport,Gas Station
-messy-variants.csv,SP *CHEVRON #6689,25,debit,Transport,Gas Station
-messy-variants.csv,COSTCO GAS #1024,25,debit,Transport,Gas Station
-messy-variants.csv,COSTCO GAS SAN LUIS OBISPO CA,25,debit,Transport,Gas Station
-messy-variants.csv,POS DEBIT SQ *COSTCO GAS,25,debit,Transport,Gas Station
-messy-variants.csv,SQ *COSTCO GAS #1024,25,debit,Transport,Gas Station
-messy-variants.csv,UBER TRIP #5578,25,debit,Transport,Rideshare
-messy-variants.csv,UBER TRIP AUSTIN TX,25,debit,Transport,Rideshare
-messy-variants.csv,RECURRING PAYMENT TST* UBER TRIP,25,debit,Transport,Rideshare
-messy-variants.csv,TST* UBER TRIP #5578,25,debit,Transport,Rideshare
-messy-variants.csv,LYFT #219,25,debit,Transport,Rideshare
-messy-variants.csv,LYFT BROOKLYN NY,25,debit,Transport,Rideshare
-messy-variants.csv,CHECKCARD PAYPAL *LYFT,25,debit,Transport,Rideshare
-messy-variants.csv,PAYPAL *LYFT #219,25,debit,Transport,Rideshare
-messy-variants.csv,GEICO #8842,25,debit,Transport,Auto Insurance
-messy-variants.csv,GEICO PORTLAND OR,25,debit,Transport,Auto Insurance
-messy-variants.csv,DEBIT CARD PURCHASE SP *GEICO,25,debit,Transport,Auto Insurance
-messy-variants.csv,SP *GEICO #8842,25,debit,Transport,Auto Insurance
-messy-variants.csv,STATE FARM #33,25,debit,Transport,Auto Insurance
-messy-variants.csv,STATE FARM DENVER CO,25,debit,Transport,Auto Insurance
-messy-variants.csv,POS DEBIT SQ *STATE FARM,25,debit,Transport,Auto Insurance
-messy-variants.csv,SQ *STATE FARM #33,25,debit,Transport,Auto Insurance
-messy-variants.csv,TFL TRAVEL #7701,25,debit,Transport,Public Transit
-messy-variants.csv,TFL TRAVEL MIAMI FL,25,debit,Transport,Public Transit
-messy-variants.csv,RECURRING PAYMENT TST* TFL TRAVEL,25,debit,Transport,Public Transit
-messy-variants.csv,TST* TFL TRAVEL #7701,25,debit,Transport,Public Transit
-messy-variants.csv,AMAZON.COM #456,25,debit,Shopping,Online Retail
-messy-variants.csv,AMAZON.COM SEATTLE WA,25,debit,Shopping,Online Retail
-messy-variants.csv,CHECKCARD PAYPAL *AMAZON.COM,25,debit,Shopping,Online Retail
-messy-variants.csv,PAYPAL *AMAZON.COM #456,25,debit,Shopping,Online Retail
-messy-variants.csv,TARGET #9012,25,debit,Shopping,Department Store
-messy-variants.csv,TARGET CHICAGO IL,25,debit,Shopping,Department Store
-messy-variants.csv,DEBIT CARD PURCHASE SP *TARGET,25,debit,Shopping,Department Store
-messy-variants.csv,SP *TARGET #9012,25,debit,Shopping,Department Store
-messy-variants.csv,BEST BUY #214,25,debit,Shopping,Electronics
-messy-variants.csv,BEST BUY PHOENIX AZ,25,debit,Shopping,Electronics
-messy-variants.csv,POS DEBIT SQ *BEST BUY,25,debit,Shopping,Electronics
-messy-variants.csv,SQ *BEST BUY #214,25,debit,Shopping,Electronics
-messy-variants.csv,HOME DEPOT #6689,25,debit,Shopping,Department Store
-messy-variants.csv,HOME DEPOT BOSTON MA,25,debit,Shopping,Department Store
-messy-variants.csv,RECURRING PAYMENT TST* HOME DEPOT,25,debit,Shopping,Department Store
-messy-variants.csv,TST* HOME DEPOT #6689,25,debit,Shopping,Department Store
-messy-variants.csv,MACYS #1024,25,debit,Shopping,Department Store
-messy-variants.csv,MACYS SAN LUIS OBISPO CA,25,debit,Shopping,Department Store
-messy-variants.csv,CHECKCARD PAYPAL *MACYS,25,debit,Shopping,Department Store
-messy-variants.csv,PAYPAL *MACYS #1024,25,debit,Shopping,Department Store
-messy-variants.csv,TJ MAXX #5578,25,debit,Shopping,Clothing
-messy-variants.csv,TJ MAXX AUSTIN TX,25,debit,Shopping,Clothing
-messy-variants.csv,DEBIT CARD PURCHASE SP *TJ MAXX,25,debit,Shopping,Clothing
-messy-variants.csv,SP *TJ MAXX #5578,25,debit,Shopping,Clothing
-messy-variants.csv,NIKE #219,25,debit,Shopping,Clothing
-messy-variants.csv,NIKE BROOKLYN NY,25,debit,Shopping,Clothing
-messy-variants.csv,POS DEBIT SQ *NIKE,25,debit,Shopping,Clothing
-messy-variants.csv,SQ *NIKE #219,25,debit,Shopping,Clothing
-messy-variants.csv,IKEA #8842,25,debit,Shopping,Department Store
-messy-variants.csv,IKEA PORTLAND OR,25,debit,Shopping,Department Store
-messy-variants.csv,RECURRING PAYMENT TST* IKEA,25,debit,Shopping,Department Store
-messy-variants.csv,TST* IKEA #8842,25,debit,Shopping,Department Store
-messy-variants.csv,SEPHORA #33,25,debit,Shopping,Department Store
-messy-variants.csv,SEPHORA DENVER CO,25,debit,Shopping,Department Store
-messy-variants.csv,CHECKCARD PAYPAL *SEPHORA,25,debit,Shopping,Department Store
-messy-variants.csv,PAYPAL *SEPHORA #33,25,debit,Shopping,Department Store
-messy-variants.csv,NETFLIX #7701,25,debit,Subscriptions,Streaming
-messy-variants.csv,NETFLIX MIAMI FL,25,debit,Subscriptions,Streaming
-messy-variants.csv,DEBIT CARD PURCHASE SP *NETFLIX,25,debit,Subscriptions,Streaming
-messy-variants.csv,SP *NETFLIX #7701,25,debit,Subscriptions,Streaming
-messy-variants.csv,SPOTIFY #456,25,debit,Subscriptions,Streaming
-messy-variants.csv,SPOTIFY SEATTLE WA,25,debit,Subscriptions,Streaming
-messy-variants.csv,POS DEBIT SQ *SPOTIFY,25,debit,Subscriptions,Streaming
-messy-variants.csv,SQ *SPOTIFY #456,25,debit,Subscriptions,Streaming
-messy-variants.csv,HULU #9012,25,debit,Subscriptions,Streaming
-messy-variants.csv,HULU CHICAGO IL,25,debit,Subscriptions,Streaming
-messy-variants.csv,RECURRING PAYMENT TST* HULU,25,debit,Subscriptions,Streaming
-messy-variants.csv,TST* HULU #9012,25,debit,Subscriptions,Streaming
-messy-variants.csv,DISNEY PLUS #214,25,debit,Subscriptions,Streaming
-messy-variants.csv,DISNEY PLUS PHOENIX AZ,25,debit,Subscriptions,Streaming
-messy-variants.csv,CHECKCARD PAYPAL *DISNEY PLUS,25,debit,Subscriptions,Streaming
-messy-variants.csv,PAYPAL *DISNEY PLUS #214,25,debit,Subscriptions,Streaming
-messy-variants.csv,ADOBE #6689,25,debit,Subscriptions,Software/SaaS
-messy-variants.csv,ADOBE BOSTON MA,25,debit,Subscriptions,Software/SaaS
-messy-variants.csv,DEBIT CARD PURCHASE SP *ADOBE,25,debit,Subscriptions,Software/SaaS
-messy-variants.csv,SP *ADOBE #6689,25,debit,Subscriptions,Software/SaaS
-messy-variants.csv,GITHUB #1024,25,debit,Subscriptions,Software/SaaS
-messy-variants.csv,GITHUB SAN LUIS OBISPO CA,25,debit,Subscriptions,Software/SaaS
-messy-variants.csv,POS DEBIT SQ *GITHUB,25,debit,Subscriptions,Software/SaaS
-messy-variants.csv,SQ *GITHUB #1024,25,debit,Subscriptions,Software/SaaS
-messy-variants.csv,DROPBOX #5578,25,debit,Subscriptions,Cloud Storage
-messy-variants.csv,DROPBOX AUSTIN TX,25,debit,Subscriptions,Cloud Storage
-messy-variants.csv,RECURRING PAYMENT TST* DROPBOX,25,debit,Subscriptions,Cloud Storage
-messy-variants.csv,TST* DROPBOX #5578,25,debit,Subscriptions,Cloud Storage
-messy-variants.csv,NYTIMES #219,25,debit,Subscriptions,News/Media
-messy-variants.csv,NYTIMES BROOKLYN NY,25,debit,Subscriptions,News/Media
-messy-variants.csv,CHECKCARD PAYPAL *NYTIMES,25,debit,Subscriptions,News/Media
-messy-variants.csv,PAYPAL *NYTIMES #219,25,debit,Subscriptions,News/Media
-messy-variants.csv,AMC THEATRES #8842,25,debit,Entertainment,Movies/Theater
-messy-variants.csv,AMC THEATRES PORTLAND OR,25,debit,Entertainment,Movies/Theater
-messy-variants.csv,DEBIT CARD PURCHASE SP *AMC THEATRES,25,debit,Entertainment,Movies/Theater
-messy-variants.csv,SP *AMC THEATRES #8842,25,debit,Entertainment,Movies/Theater
-messy-variants.csv,TICKETMASTER #33,25,debit,Entertainment,Concert/Event
-messy-variants.csv,TICKETMASTER DENVER CO,25,debit,Entertainment,Concert/Event
-messy-variants.csv,POS DEBIT SQ *TICKETMASTER,25,debit,Entertainment,Concert/Event
-messy-variants.csv,SQ *TICKETMASTER #33,25,debit,Entertainment,Concert/Event
-messy-variants.csv,STEAM PURCHASE #7701,25,debit,Entertainment,Gaming
-messy-variants.csv,STEAM PURCHASE MIAMI FL,25,debit,Entertainment,Gaming
-messy-variants.csv,RECURRING PAYMENT TST* STEAM PURCHASE,25,debit,Entertainment,Gaming
-messy-variants.csv,TST* STEAM PURCHASE #7701,25,debit,Entertainment,Gaming
-messy-variants.csv,PLAYSTATION NETWORK #456,25,debit,Entertainment,Gaming
-messy-variants.csv,PLAYSTATION NETWORK SEATTLE WA,25,debit,Entertainment,Gaming
-messy-variants.csv,CHECKCARD PAYPAL *PLAYSTATION NETWORK,25,debit,Entertainment,Gaming
-messy-variants.csv,PAYPAL *PLAYSTATION NETWORK #456,25,debit,Entertainment,Gaming
-messy-variants.csv,TOTAL WINE #9012,25,debit,Entertainment,Nightlife
-messy-variants.csv,TOTAL WINE CHICAGO IL,25,debit,Entertainment,Nightlife
-messy-variants.csv,DEBIT CARD PURCHASE SP *TOTAL WINE,25,debit,Entertainment,Nightlife
-messy-variants.csv,SP *TOTAL WINE #9012,25,debit,Entertainment,Nightlife
-messy-variants.csv,CVS PHARMACY #214,25,debit,Health,Pharmacy
-messy-variants.csv,CVS PHARMACY PHOENIX AZ,25,debit,Health,Pharmacy
-messy-variants.csv,POS DEBIT SQ *CVS PHARMACY,25,debit,Health,Pharmacy
-messy-variants.csv,SQ *CVS PHARMACY #214,25,debit,Health,Pharmacy
-messy-variants.csv,WALGREENS #6689,25,debit,Health,Pharmacy
-messy-variants.csv,WALGREENS BOSTON MA,25,debit,Health,Pharmacy
-messy-variants.csv,RECURRING PAYMENT TST* WALGREENS,25,debit,Health,Pharmacy
-messy-variants.csv,TST* WALGREENS #6689,25,debit,Health,Pharmacy
-messy-variants.csv,PLANET FITNESS #1024,25,debit,Health,Gym
-messy-variants.csv,PLANET FITNESS SAN LUIS OBISPO CA,25,debit,Health,Gym
-messy-variants.csv,CHECKCARD PAYPAL *PLANET FITNESS,25,debit,Health,Gym
-messy-variants.csv,PAYPAL *PLANET FITNESS #1024,25,debit,Health,Gym
-messy-variants.csv,EQUINOX #5578,25,debit,Health,Gym
-messy-variants.csv,EQUINOX AUSTIN TX,25,debit,Health,Gym
-messy-variants.csv,DEBIT CARD PURCHASE SP *EQUINOX,25,debit,Health,Gym
-messy-variants.csv,SP *EQUINOX #5578,25,debit,Health,Gym
-messy-variants.csv,ASPEN DENTAL #219,25,debit,Health,Dentist
-messy-variants.csv,ASPEN DENTAL BROOKLYN NY,25,debit,Health,Dentist
-messy-variants.csv,POS DEBIT SQ *ASPEN DENTAL,25,debit,Health,Dentist
-messy-variants.csv,SQ *ASPEN DENTAL #219,25,debit,Health,Dentist
-messy-variants.csv,WARBY PARKER #8842,25,debit,Health,Vision
-messy-variants.csv,WARBY PARKER PORTLAND OR,25,debit,Health,Vision
-messy-variants.csv,RECURRING PAYMENT TST* WARBY PARKER,25,debit,Health,Vision
-messy-variants.csv,TST* WARBY PARKER #8842,25,debit,Health,Vision
-messy-variants.csv,DELTA AIR LINES #33,25,debit,Travel,Flight
-messy-variants.csv,DELTA AIR LINES DENVER CO,25,debit,Travel,Flight
-messy-variants.csv,CHECKCARD PAYPAL *DELTA AIR LINES,25,debit,Travel,Flight
-messy-variants.csv,PAYPAL *DELTA AIR LINES #33,25,debit,Travel,Flight
-messy-variants.csv,UNITED AIRLINES #7701,25,debit,Travel,Flight
-messy-variants.csv,UNITED AIRLINES MIAMI FL,25,debit,Travel,Flight
-messy-variants.csv,DEBIT CARD PURCHASE SP *UNITED AIRLINES,25,debit,Travel,Flight
-messy-variants.csv,SP *UNITED AIRLINES #7701,25,debit,Travel,Flight
-messy-variants.csv,MARRIOTT #456,25,debit,Travel,Hotel
-messy-variants.csv,MARRIOTT SEATTLE WA,25,debit,Travel,Hotel
-messy-variants.csv,POS DEBIT SQ *MARRIOTT,25,debit,Travel,Hotel
-messy-variants.csv,SQ *MARRIOTT #456,25,debit,Travel,Hotel
-messy-variants.csv,HILTON #9012,25,debit,Travel,Hotel
-messy-variants.csv,HILTON CHICAGO IL,25,debit,Travel,Hotel
-messy-variants.csv,RECURRING PAYMENT TST* HILTON,25,debit,Travel,Hotel
-messy-variants.csv,TST* HILTON #9012,25,debit,Travel,Hotel
-messy-variants.csv,AIRBNB #214,25,debit,Travel,Vacation Rental
-messy-variants.csv,AIRBNB PHOENIX AZ,25,debit,Travel,Vacation Rental
-messy-variants.csv,CHECKCARD PAYPAL *AIRBNB,25,debit,Travel,Vacation Rental
-messy-variants.csv,PAYPAL *AIRBNB #214,25,debit,Travel,Vacation Rental
-messy-variants.csv,HERTZ RENT A CAR #6689,25,debit,Travel,Car Rental
-messy-variants.csv,HERTZ RENT A CAR BOSTON MA,25,debit,Travel,Car Rental
-messy-variants.csv,DEBIT CARD PURCHASE SP *HERTZ RENT A CAR,25,debit,Travel,Car Rental
-messy-variants.csv,SP *HERTZ RENT A CAR #6689,25,debit,Travel,Car Rental
-messy-variants.csv,PG&E ELECTRIC #1024,25,debit,Housing,Utilities
-messy-variants.csv,PG&E ELECTRIC SAN LUIS OBISPO CA,25,debit,Housing,Utilities
-messy-variants.csv,POS DEBIT SQ *PG&E ELECTRIC,25,debit,Housing,Utilities
-messy-variants.csv,SQ *PG&E ELECTRIC #1024,25,debit,Housing,Utilities
-messy-variants.csv,COMCAST XFINITY #5578,25,debit,Housing,Internet/Cable
-messy-variants.csv,COMCAST XFINITY AUSTIN TX,25,debit,Housing,Internet/Cable
-messy-variants.csv,RECURRING PAYMENT TST* COMCAST XFINITY,25,debit,Housing,Internet/Cable
-messy-variants.csv,TST* COMCAST XFINITY #5578,25,debit,Housing,Internet/Cable
-messy-variants.csv,AT&T WIRELESS #219,25,debit,Housing,Phone Bill
-messy-variants.csv,AT&T WIRELESS BROOKLYN NY,25,debit,Housing,Phone Bill
-messy-variants.csv,CHECKCARD PAYPAL *AT&T WIRELESS,25,debit,Housing,Phone Bill
-messy-variants.csv,PAYPAL *AT&T WIRELESS #219,25,debit,Housing,Phone Bill
-messy-variants.csv,VERIZON WIRELESS #8842,25,debit,Housing,Phone Bill
-messy-variants.csv,VERIZON WIRELESS PORTLAND OR,25,debit,Housing,Phone Bill
-messy-variants.csv,DEBIT CARD PURCHASE SP *VERIZON WIRELESS,25,debit,Housing,Phone Bill
-messy-variants.csv,SP *VERIZON WIRELESS #8842,25,debit,Housing,Phone Bill
-messy-variants.csv,BRIGHT HORIZONS #33,25,debit,Childcare,Daycare
-messy-variants.csv,BRIGHT HORIZONS DENVER CO,25,debit,Childcare,Daycare
-messy-variants.csv,POS DEBIT SQ *BRIGHT HORIZONS,25,debit,Childcare,Daycare
-messy-variants.csv,SQ *BRIGHT HORIZONS #33,25,debit,Childcare,Daycare
-messy-variants.csv,KINDERCARE #7701,25,debit,Childcare,Daycare
-messy-variants.csv,KINDERCARE MIAMI FL,25,debit,Childcare,Daycare
-messy-variants.csv,RECURRING PAYMENT TST* KINDERCARE,25,debit,Childcare,Daycare
-messy-variants.csv,TST* KINDERCARE #7701,25,debit,Childcare,Daycare
-messy-variants.csv,MONTESSORI ACADEMY #456,25,debit,Childcare,Preschool
-messy-variants.csv,MONTESSORI ACADEMY SEATTLE WA,25,debit,Childcare,Preschool
-messy-variants.csv,CHECKCARD PAYPAL *MONTESSORI ACADEMY,25,debit,Childcare,Preschool
-messy-variants.csv,PAYPAL *MONTESSORI ACADEMY #456,25,debit,Childcare,Preschool
-messy-variants.csv,NAVIENT STUDENT LOAN #9012,25,debit,Education,Student Loan
-messy-variants.csv,NAVIENT STUDENT LOAN CHICAGO IL,25,debit,Education,Student Loan
-messy-variants.csv,DEBIT CARD PURCHASE SP *NAVIENT STUDENT LOAN,25,debit,Education,Student Loan
-messy-variants.csv,SP *NAVIENT STUDENT LOAN #9012,25,debit,Education,Student Loan
-messy-variants.csv,KUMON MATH CENTER #214,25,debit,Education,Tutoring
-messy-variants.csv,KUMON MATH CENTER PHOENIX AZ,25,debit,Education,Tutoring
-messy-variants.csv,POS DEBIT SQ *KUMON MATH CENTER,25,debit,Education,Tutoring
-messy-variants.csv,SQ *KUMON MATH CENTER #214,25,debit,Education,Tutoring
-messy-variants.csv,COURSERA #6689,25,debit,Education,Online Course
-messy-variants.csv,COURSERA BOSTON MA,25,debit,Education,Online Course
-messy-variants.csv,RECURRING PAYMENT TST* COURSERA,25,debit,Education,Online Course
-messy-variants.csv,TST* COURSERA #6689,25,debit,Education,Online Course
-messy-variants.csv,VENMO #1024,25,debit,Transfer,Transfer
-messy-variants.csv,VENMO SAN LUIS OBISPO CA,25,debit,Transfer,Transfer
-messy-variants.csv,CHECKCARD PAYPAL *VENMO,25,debit,Transfer,Transfer
-messy-variants.csv,PAYPAL *VENMO #1024,25,debit,Transfer,Transfer
-messy-variants.csv,ZELLE #5578,25,debit,Transfer,Transfer
-messy-variants.csv,ZELLE AUSTIN TX,25,debit,Transfer,Transfer
-messy-variants.csv,DEBIT CARD PURCHASE SP *ZELLE,25,debit,Transfer,Transfer
-messy-variants.csv,SP *ZELLE #5578,25,debit,Transfer,Transfer
-messy-variants.csv,DIRECT DEPOSIT PAYROLL #219,25,credit,Income,Payroll
-messy-variants.csv,DIRECT DEPOSIT PAYROLL BROOKLYN NY,25,credit,Income,Payroll
-messy-variants.csv,POS DEBIT SQ *DIRECT DEPOSIT PAYROLL,25,credit,Income,Payroll
-messy-variants.csv,SQ *DIRECT DEPOSIT PAYROLL #219,25,credit,Income,Payroll
-messy-variants.csv,ADP PAYROLL #8842,25,credit,Income,Payroll
-messy-variants.csv,ADP PAYROLL PORTLAND OR,25,credit,Income,Payroll
-messy-variants.csv,RECURRING PAYMENT TST* ADP PAYROLL,25,credit,Income,Payroll
-messy-variants.csv,TST* ADP PAYROLL #8842,25,credit,Income,Payroll
-messy-variants.csv,INTEREST PAYMENT #33,25,credit,Income,Interest
-messy-variants.csv,INTEREST PAYMENT DENVER CO,25,credit,Income,Interest
-messy-variants.csv,CHECKCARD PAYPAL *INTEREST PAYMENT,25,credit,Income,Interest
-messy-variants.csv,PAYPAL *INTEREST PAYMENT #33,25,credit,Income,Interest
-messy-variants.csv,OAKWOOD APTS RENT #7701,25,debit,Housing,Rent
-messy-variants.csv,OAKWOOD APTS RENT MIAMI FL,25,debit,Housing,Rent
-messy-variants.csv,DEBIT CARD PURCHASE SP *OAKWOOD APTS RENT,25,debit,Housing,Rent
-messy-variants.csv,SP *OAKWOOD APTS RENT #7701,25,debit,Housing,Rent
-messy-variants.csv,GOLDEN GYM FITNESS #456,25,debit,Health,Gym
-messy-variants.csv,GOLDEN GYM FITNESS SEATTLE WA,25,debit,Health,Gym
-messy-variants.csv,POS DEBIT SQ *GOLDEN GYM FITNESS,25,debit,Health,Gym
-messy-variants.csv,SQ *GOLDEN GYM FITNESS #456,25,debit,Health,Gym
-messy-variants.csv,RIVERVIEW MEDICAL CLINIC #9012,25,debit,Health,Doctor/Medical
-messy-variants.csv,RIVERVIEW MEDICAL CLINIC CHICAGO IL,25,debit,Health,Doctor/Medical
-messy-variants.csv,RECURRING PAYMENT TST* RIVERVIEW MEDICAL CLINIC,25,debit,Health,Doctor/Medical
-messy-variants.csv,TST* RIVERVIEW MEDICAL CLINIC #9012,25,debit,Health,Doctor/Medical
-messy-variants.csv,HOPE CHARITY DONATION #214,25,debit,Other,Donation
-messy-variants.csv,HOPE CHARITY DONATION PHOENIX AZ,25,debit,Other,Donation
-messy-variants.csv,CHECKCARD PAYPAL *HOPE CHARITY DONATION,25,debit,Other,Donation
-messy-variants.csv,PAYPAL *HOPE CHARITY DONATION #214,25,debit,Other,Donation
-messy-variants.csv,MAPLEWOOD PROPERTY MANAGEMENT #6689,25,debit,Housing,Rent
-messy-variants.csv,MAPLEWOOD PROPERTY MANAGEMENT BOSTON MA,25,debit,Housing,Rent
-messy-variants.csv,DEBIT CARD PURCHASE SP *MAPLEWOOD PROPERTY MANAGEMENT,25,debit,Housing,Rent
-messy-variants.csv,SP *MAPLEWOOD PROPERTY MANAGEMENT #6689,25,debit,Housing,Rent
+sourceFile,description,amount,type,category,subcategory,bankCategory
+messy-variants.csv,STARBUCKS #1024,25,debit,Dining,Coffee Shop,
+messy-variants.csv,STARBUCKS SAN LUIS OBISPO CA,25,debit,Dining,Coffee Shop,
+messy-variants.csv,POS DEBIT SQ *STARBUCKS,25,debit,Dining,Coffee Shop,
+messy-variants.csv,SQ *STARBUCKS #1024,25,debit,Dining,Coffee Shop,
+messy-variants.csv,BLUE BOTTLE COFFEE #5578,25,debit,Dining,Coffee Shop,
+messy-variants.csv,BLUE BOTTLE COFFEE AUSTIN TX,25,debit,Dining,Coffee Shop,
+messy-variants.csv,RECURRING PAYMENT TST* BLUE BOTTLE COFFEE,25,debit,Dining,Coffee Shop,
+messy-variants.csv,TST* BLUE BOTTLE COFFEE #5578,25,debit,Dining,Coffee Shop,
+messy-variants.csv,DUNKIN #219,25,debit,Dining,Coffee Shop,
+messy-variants.csv,DUNKIN BROOKLYN NY,25,debit,Dining,Coffee Shop,
+messy-variants.csv,CHECKCARD PAYPAL *DUNKIN,25,debit,Dining,Coffee Shop,
+messy-variants.csv,PAYPAL *DUNKIN #219,25,debit,Dining,Coffee Shop,
+messy-variants.csv,MCDONALDS #8842,25,debit,Dining,Fast Food,
+messy-variants.csv,MCDONALDS PORTLAND OR,25,debit,Dining,Fast Food,
+messy-variants.csv,DEBIT CARD PURCHASE SP *MCDONALDS,25,debit,Dining,Fast Food,
+messy-variants.csv,SP *MCDONALDS #8842,25,debit,Dining,Fast Food,
+messy-variants.csv,CHIPOTLE #33,25,debit,Dining,Fast Food,
+messy-variants.csv,CHIPOTLE DENVER CO,25,debit,Dining,Fast Food,
+messy-variants.csv,POS DEBIT SQ *CHIPOTLE,25,debit,Dining,Fast Food,
+messy-variants.csv,SQ *CHIPOTLE #33,25,debit,Dining,Fast Food,
+messy-variants.csv,CHICK-FIL-A #7701,25,debit,Dining,Fast Food,
+messy-variants.csv,CHICK-FIL-A MIAMI FL,25,debit,Dining,Fast Food,
+messy-variants.csv,RECURRING PAYMENT TST* CHICK-FIL-A,25,debit,Dining,Fast Food,
+messy-variants.csv,TST* CHICK-FIL-A #7701,25,debit,Dining,Fast Food,
+messy-variants.csv,FIVE GUYS #456,25,debit,Dining,Fast Food,
+messy-variants.csv,FIVE GUYS SEATTLE WA,25,debit,Dining,Fast Food,
+messy-variants.csv,CHECKCARD PAYPAL *FIVE GUYS,25,debit,Dining,Fast Food,
+messy-variants.csv,PAYPAL *FIVE GUYS #456,25,debit,Dining,Fast Food,
+messy-variants.csv,OLIVE GARDEN #9012,25,debit,Dining,Restaurant,
+messy-variants.csv,OLIVE GARDEN CHICAGO IL,25,debit,Dining,Restaurant,
+messy-variants.csv,DEBIT CARD PURCHASE SP *OLIVE GARDEN,25,debit,Dining,Restaurant,
+messy-variants.csv,SP *OLIVE GARDEN #9012,25,debit,Dining,Restaurant,
+messy-variants.csv,DOORDASH #214,25,debit,Dining,Food Delivery,
+messy-variants.csv,DOORDASH PHOENIX AZ,25,debit,Dining,Food Delivery,
+messy-variants.csv,POS DEBIT SQ *DOORDASH,25,debit,Dining,Food Delivery,
+messy-variants.csv,SQ *DOORDASH #214,25,debit,Dining,Food Delivery,
+messy-variants.csv,GRUBHUB #6689,25,debit,Dining,Food Delivery,
+messy-variants.csv,GRUBHUB BOSTON MA,25,debit,Dining,Food Delivery,
+messy-variants.csv,RECURRING PAYMENT TST* GRUBHUB,25,debit,Dining,Food Delivery,
+messy-variants.csv,TST* GRUBHUB #6689,25,debit,Dining,Food Delivery,
+messy-variants.csv,WHOLE FOODS MARKET #1024,25,debit,Groceries,Specialty Food,
+messy-variants.csv,WHOLE FOODS MARKET SAN LUIS OBISPO CA,25,debit,Groceries,Specialty Food,
+messy-variants.csv,CHECKCARD PAYPAL *WHOLE FOODS MARKET,25,debit,Groceries,Specialty Food,
+messy-variants.csv,PAYPAL *WHOLE FOODS MARKET #1024,25,debit,Groceries,Specialty Food,
+messy-variants.csv,TRADER JOES #5578,25,debit,Groceries,Specialty Food,
+messy-variants.csv,TRADER JOES AUSTIN TX,25,debit,Groceries,Specialty Food,
+messy-variants.csv,DEBIT CARD PURCHASE SP *TRADER JOES,25,debit,Groceries,Specialty Food,
+messy-variants.csv,SP *TRADER JOES #5578,25,debit,Groceries,Specialty Food,
+messy-variants.csv,KROGER #219,25,debit,Groceries,Supermarket,
+messy-variants.csv,KROGER BROOKLYN NY,25,debit,Groceries,Supermarket,
+messy-variants.csv,POS DEBIT SQ *KROGER,25,debit,Groceries,Supermarket,
+messy-variants.csv,SQ *KROGER #219,25,debit,Groceries,Supermarket,
+messy-variants.csv,SAFEWAY #8842,25,debit,Groceries,Supermarket,
+messy-variants.csv,SAFEWAY PORTLAND OR,25,debit,Groceries,Supermarket,
+messy-variants.csv,RECURRING PAYMENT TST* SAFEWAY,25,debit,Groceries,Supermarket,
+messy-variants.csv,TST* SAFEWAY #8842,25,debit,Groceries,Supermarket,
+messy-variants.csv,COSTCO WHSE #33,25,debit,Groceries,Warehouse Club,
+messy-variants.csv,COSTCO WHSE DENVER CO,25,debit,Groceries,Warehouse Club,
+messy-variants.csv,CHECKCARD PAYPAL *COSTCO WHSE,25,debit,Groceries,Warehouse Club,
+messy-variants.csv,PAYPAL *COSTCO WHSE #33,25,debit,Groceries,Warehouse Club,
+messy-variants.csv,INSTACART #7701,25,debit,Groceries,Grocery Delivery,
+messy-variants.csv,INSTACART MIAMI FL,25,debit,Groceries,Grocery Delivery,
+messy-variants.csv,DEBIT CARD PURCHASE SP *INSTACART,25,debit,Groceries,Grocery Delivery,
+messy-variants.csv,SP *INSTACART #7701,25,debit,Groceries,Grocery Delivery,
+messy-variants.csv,TESCO #456,25,debit,Groceries,Supermarket,
+messy-variants.csv,TESCO SEATTLE WA,25,debit,Groceries,Supermarket,
+messy-variants.csv,POS DEBIT SQ *TESCO,25,debit,Groceries,Supermarket,
+messy-variants.csv,SQ *TESCO #456,25,debit,Groceries,Supermarket,
+messy-variants.csv,SAINSBURY'S #9012,25,debit,Groceries,Supermarket,
+messy-variants.csv,SAINSBURY'S CHICAGO IL,25,debit,Groceries,Supermarket,
+messy-variants.csv,RECURRING PAYMENT TST* SAINSBURY'S,25,debit,Groceries,Supermarket,
+messy-variants.csv,TST* SAINSBURY'S #9012,25,debit,Groceries,Supermarket,
+messy-variants.csv,SHELL OIL #214,25,debit,Transport,Gas Station,
+messy-variants.csv,SHELL OIL PHOENIX AZ,25,debit,Transport,Gas Station,
+messy-variants.csv,CHECKCARD PAYPAL *SHELL OIL,25,debit,Transport,Gas Station,
+messy-variants.csv,PAYPAL *SHELL OIL #214,25,debit,Transport,Gas Station,
+messy-variants.csv,CHEVRON #6689,25,debit,Transport,Gas Station,
+messy-variants.csv,CHEVRON BOSTON MA,25,debit,Transport,Gas Station,
+messy-variants.csv,DEBIT CARD PURCHASE SP *CHEVRON,25,debit,Transport,Gas Station,
+messy-variants.csv,SP *CHEVRON #6689,25,debit,Transport,Gas Station,
+messy-variants.csv,COSTCO GAS #1024,25,debit,Transport,Gas Station,
+messy-variants.csv,COSTCO GAS SAN LUIS OBISPO CA,25,debit,Transport,Gas Station,
+messy-variants.csv,POS DEBIT SQ *COSTCO GAS,25,debit,Transport,Gas Station,
+messy-variants.csv,SQ *COSTCO GAS #1024,25,debit,Transport,Gas Station,
+messy-variants.csv,UBER TRIP #5578,25,debit,Transport,Rideshare,
+messy-variants.csv,UBER TRIP AUSTIN TX,25,debit,Transport,Rideshare,
+messy-variants.csv,RECURRING PAYMENT TST* UBER TRIP,25,debit,Transport,Rideshare,
+messy-variants.csv,TST* UBER TRIP #5578,25,debit,Transport,Rideshare,
+messy-variants.csv,LYFT #219,25,debit,Transport,Rideshare,
+messy-variants.csv,LYFT BROOKLYN NY,25,debit,Transport,Rideshare,
+messy-variants.csv,CHECKCARD PAYPAL *LYFT,25,debit,Transport,Rideshare,
+messy-variants.csv,PAYPAL *LYFT #219,25,debit,Transport,Rideshare,
+messy-variants.csv,GEICO #8842,25,debit,Transport,Auto Insurance,
+messy-variants.csv,GEICO PORTLAND OR,25,debit,Transport,Auto Insurance,
+messy-variants.csv,DEBIT CARD PURCHASE SP *GEICO,25,debit,Transport,Auto Insurance,
+messy-variants.csv,SP *GEICO #8842,25,debit,Transport,Auto Insurance,
+messy-variants.csv,STATE FARM #33,25,debit,Transport,Auto Insurance,
+messy-variants.csv,STATE FARM DENVER CO,25,debit,Transport,Auto Insurance,
+messy-variants.csv,POS DEBIT SQ *STATE FARM,25,debit,Transport,Auto Insurance,
+messy-variants.csv,SQ *STATE FARM #33,25,debit,Transport,Auto Insurance,
+messy-variants.csv,TFL TRAVEL #7701,25,debit,Transport,Public Transit,
+messy-variants.csv,TFL TRAVEL MIAMI FL,25,debit,Transport,Public Transit,
+messy-variants.csv,RECURRING PAYMENT TST* TFL TRAVEL,25,debit,Transport,Public Transit,
+messy-variants.csv,TST* TFL TRAVEL #7701,25,debit,Transport,Public Transit,
+messy-variants.csv,AMAZON.COM #456,25,debit,Shopping,Online Retail,
+messy-variants.csv,AMAZON.COM SEATTLE WA,25,debit,Shopping,Online Retail,
+messy-variants.csv,CHECKCARD PAYPAL *AMAZON.COM,25,debit,Shopping,Online Retail,
+messy-variants.csv,PAYPAL *AMAZON.COM #456,25,debit,Shopping,Online Retail,
+messy-variants.csv,TARGET #9012,25,debit,Shopping,Department Store,
+messy-variants.csv,TARGET CHICAGO IL,25,debit,Shopping,Department Store,
+messy-variants.csv,DEBIT CARD PURCHASE SP *TARGET,25,debit,Shopping,Department Store,
+messy-variants.csv,SP *TARGET #9012,25,debit,Shopping,Department Store,
+messy-variants.csv,BEST BUY #214,25,debit,Shopping,Electronics,
+messy-variants.csv,BEST BUY PHOENIX AZ,25,debit,Shopping,Electronics,
+messy-variants.csv,POS DEBIT SQ *BEST BUY,25,debit,Shopping,Electronics,
+messy-variants.csv,SQ *BEST BUY #214,25,debit,Shopping,Electronics,
+messy-variants.csv,HOME DEPOT #6689,25,debit,Shopping,Department Store,
+messy-variants.csv,HOME DEPOT BOSTON MA,25,debit,Shopping,Department Store,
+messy-variants.csv,RECURRING PAYMENT TST* HOME DEPOT,25,debit,Shopping,Department Store,
+messy-variants.csv,TST* HOME DEPOT #6689,25,debit,Shopping,Department Store,
+messy-variants.csv,MACYS #1024,25,debit,Shopping,Department Store,
+messy-variants.csv,MACYS SAN LUIS OBISPO CA,25,debit,Shopping,Department Store,
+messy-variants.csv,CHECKCARD PAYPAL *MACYS,25,debit,Shopping,Department Store,
+messy-variants.csv,PAYPAL *MACYS #1024,25,debit,Shopping,Department Store,
+messy-variants.csv,TJ MAXX #5578,25,debit,Shopping,Clothing,
+messy-variants.csv,TJ MAXX AUSTIN TX,25,debit,Shopping,Clothing,
+messy-variants.csv,DEBIT CARD PURCHASE SP *TJ MAXX,25,debit,Shopping,Clothing,
+messy-variants.csv,SP *TJ MAXX #5578,25,debit,Shopping,Clothing,
+messy-variants.csv,NIKE #219,25,debit,Shopping,Clothing,
+messy-variants.csv,NIKE BROOKLYN NY,25,debit,Shopping,Clothing,
+messy-variants.csv,POS DEBIT SQ *NIKE,25,debit,Shopping,Clothing,
+messy-variants.csv,SQ *NIKE #219,25,debit,Shopping,Clothing,
+messy-variants.csv,IKEA #8842,25,debit,Shopping,Department Store,
+messy-variants.csv,IKEA PORTLAND OR,25,debit,Shopping,Department Store,
+messy-variants.csv,RECURRING PAYMENT TST* IKEA,25,debit,Shopping,Department Store,
+messy-variants.csv,TST* IKEA #8842,25,debit,Shopping,Department Store,
+messy-variants.csv,SEPHORA #33,25,debit,Shopping,Department Store,
+messy-variants.csv,SEPHORA DENVER CO,25,debit,Shopping,Department Store,
+messy-variants.csv,CHECKCARD PAYPAL *SEPHORA,25,debit,Shopping,Department Store,
+messy-variants.csv,PAYPAL *SEPHORA #33,25,debit,Shopping,Department Store,
+messy-variants.csv,NETFLIX #7701,25,debit,Subscriptions,Streaming,
+messy-variants.csv,NETFLIX MIAMI FL,25,debit,Subscriptions,Streaming,
+messy-variants.csv,DEBIT CARD PURCHASE SP *NETFLIX,25,debit,Subscriptions,Streaming,
+messy-variants.csv,SP *NETFLIX #7701,25,debit,Subscriptions,Streaming,
+messy-variants.csv,SPOTIFY #456,25,debit,Subscriptions,Streaming,
+messy-variants.csv,SPOTIFY SEATTLE WA,25,debit,Subscriptions,Streaming,
+messy-variants.csv,POS DEBIT SQ *SPOTIFY,25,debit,Subscriptions,Streaming,
+messy-variants.csv,SQ *SPOTIFY #456,25,debit,Subscriptions,Streaming,
+messy-variants.csv,HULU #9012,25,debit,Subscriptions,Streaming,
+messy-variants.csv,HULU CHICAGO IL,25,debit,Subscriptions,Streaming,
+messy-variants.csv,RECURRING PAYMENT TST* HULU,25,debit,Subscriptions,Streaming,
+messy-variants.csv,TST* HULU #9012,25,debit,Subscriptions,Streaming,
+messy-variants.csv,DISNEY PLUS #214,25,debit,Subscriptions,Streaming,
+messy-variants.csv,DISNEY PLUS PHOENIX AZ,25,debit,Subscriptions,Streaming,
+messy-variants.csv,CHECKCARD PAYPAL *DISNEY PLUS,25,debit,Subscriptions,Streaming,
+messy-variants.csv,PAYPAL *DISNEY PLUS #214,25,debit,Subscriptions,Streaming,
+messy-variants.csv,ADOBE #6689,25,debit,Subscriptions,Software/SaaS,
+messy-variants.csv,ADOBE BOSTON MA,25,debit,Subscriptions,Software/SaaS,
+messy-variants.csv,DEBIT CARD PURCHASE SP *ADOBE,25,debit,Subscriptions,Software/SaaS,
+messy-variants.csv,SP *ADOBE #6689,25,debit,Subscriptions,Software/SaaS,
+messy-variants.csv,GITHUB #1024,25,debit,Subscriptions,Software/SaaS,
+messy-variants.csv,GITHUB SAN LUIS OBISPO CA,25,debit,Subscriptions,Software/SaaS,
+messy-variants.csv,POS DEBIT SQ *GITHUB,25,debit,Subscriptions,Software/SaaS,
+messy-variants.csv,SQ *GITHUB #1024,25,debit,Subscriptions,Software/SaaS,
+messy-variants.csv,DROPBOX #5578,25,debit,Subscriptions,Cloud Storage,
+messy-variants.csv,DROPBOX AUSTIN TX,25,debit,Subscriptions,Cloud Storage,
+messy-variants.csv,RECURRING PAYMENT TST* DROPBOX,25,debit,Subscriptions,Cloud Storage,
+messy-variants.csv,TST* DROPBOX #5578,25,debit,Subscriptions,Cloud Storage,
+messy-variants.csv,NYTIMES #219,25,debit,Subscriptions,News/Media,
+messy-variants.csv,NYTIMES BROOKLYN NY,25,debit,Subscriptions,News/Media,
+messy-variants.csv,CHECKCARD PAYPAL *NYTIMES,25,debit,Subscriptions,News/Media,
+messy-variants.csv,PAYPAL *NYTIMES #219,25,debit,Subscriptions,News/Media,
+messy-variants.csv,AMC THEATRES #8842,25,debit,Entertainment,Movies/Theater,
+messy-variants.csv,AMC THEATRES PORTLAND OR,25,debit,Entertainment,Movies/Theater,
+messy-variants.csv,DEBIT CARD PURCHASE SP *AMC THEATRES,25,debit,Entertainment,Movies/Theater,
+messy-variants.csv,SP *AMC THEATRES #8842,25,debit,Entertainment,Movies/Theater,
+messy-variants.csv,TICKETMASTER #33,25,debit,Entertainment,Concert/Event,
+messy-variants.csv,TICKETMASTER DENVER CO,25,debit,Entertainment,Concert/Event,
+messy-variants.csv,POS DEBIT SQ *TICKETMASTER,25,debit,Entertainment,Concert/Event,
+messy-variants.csv,SQ *TICKETMASTER #33,25,debit,Entertainment,Concert/Event,
+messy-variants.csv,STEAM PURCHASE #7701,25,debit,Entertainment,Gaming,
+messy-variants.csv,STEAM PURCHASE MIAMI FL,25,debit,Entertainment,Gaming,
+messy-variants.csv,RECURRING PAYMENT TST* STEAM PURCHASE,25,debit,Entertainment,Gaming,
+messy-variants.csv,TST* STEAM PURCHASE #7701,25,debit,Entertainment,Gaming,
+messy-variants.csv,PLAYSTATION NETWORK #456,25,debit,Entertainment,Gaming,
+messy-variants.csv,PLAYSTATION NETWORK SEATTLE WA,25,debit,Entertainment,Gaming,
+messy-variants.csv,CHECKCARD PAYPAL *PLAYSTATION NETWORK,25,debit,Entertainment,Gaming,
+messy-variants.csv,PAYPAL *PLAYSTATION NETWORK #456,25,debit,Entertainment,Gaming,
+messy-variants.csv,TOTAL WINE #9012,25,debit,Entertainment,Nightlife,
+messy-variants.csv,TOTAL WINE CHICAGO IL,25,debit,Entertainment,Nightlife,
+messy-variants.csv,DEBIT CARD PURCHASE SP *TOTAL WINE,25,debit,Entertainment,Nightlife,
+messy-variants.csv,SP *TOTAL WINE #9012,25,debit,Entertainment,Nightlife,
+messy-variants.csv,CVS PHARMACY #214,25,debit,Health,Pharmacy,
+messy-variants.csv,CVS PHARMACY PHOENIX AZ,25,debit,Health,Pharmacy,
+messy-variants.csv,POS DEBIT SQ *CVS PHARMACY,25,debit,Health,Pharmacy,
+messy-variants.csv,SQ *CVS PHARMACY #214,25,debit,Health,Pharmacy,
+messy-variants.csv,WALGREENS #6689,25,debit,Health,Pharmacy,
+messy-variants.csv,WALGREENS BOSTON MA,25,debit,Health,Pharmacy,
+messy-variants.csv,RECURRING PAYMENT TST* WALGREENS,25,debit,Health,Pharmacy,
+messy-variants.csv,TST* WALGREENS #6689,25,debit,Health,Pharmacy,
+messy-variants.csv,PLANET FITNESS #1024,25,debit,Health,Gym,
+messy-variants.csv,PLANET FITNESS SAN LUIS OBISPO CA,25,debit,Health,Gym,
+messy-variants.csv,CHECKCARD PAYPAL *PLANET FITNESS,25,debit,Health,Gym,
+messy-variants.csv,PAYPAL *PLANET FITNESS #1024,25,debit,Health,Gym,
+messy-variants.csv,EQUINOX #5578,25,debit,Health,Gym,
+messy-variants.csv,EQUINOX AUSTIN TX,25,debit,Health,Gym,
+messy-variants.csv,DEBIT CARD PURCHASE SP *EQUINOX,25,debit,Health,Gym,
+messy-variants.csv,SP *EQUINOX #5578,25,debit,Health,Gym,
+messy-variants.csv,ASPEN DENTAL #219,25,debit,Health,Dentist,
+messy-variants.csv,ASPEN DENTAL BROOKLYN NY,25,debit,Health,Dentist,
+messy-variants.csv,POS DEBIT SQ *ASPEN DENTAL,25,debit,Health,Dentist,
+messy-variants.csv,SQ *ASPEN DENTAL #219,25,debit,Health,Dentist,
+messy-variants.csv,WARBY PARKER #8842,25,debit,Health,Vision,
+messy-variants.csv,WARBY PARKER PORTLAND OR,25,debit,Health,Vision,
+messy-variants.csv,RECURRING PAYMENT TST* WARBY PARKER,25,debit,Health,Vision,
+messy-variants.csv,TST* WARBY PARKER #8842,25,debit,Health,Vision,
+messy-variants.csv,DELTA AIR LINES #33,25,debit,Travel,Flight,
+messy-variants.csv,DELTA AIR LINES DENVER CO,25,debit,Travel,Flight,
+messy-variants.csv,CHECKCARD PAYPAL *DELTA AIR LINES,25,debit,Travel,Flight,
+messy-variants.csv,PAYPAL *DELTA AIR LINES #33,25,debit,Travel,Flight,
+messy-variants.csv,UNITED AIRLINES #7701,25,debit,Travel,Flight,
+messy-variants.csv,UNITED AIRLINES MIAMI FL,25,debit,Travel,Flight,
+messy-variants.csv,DEBIT CARD PURCHASE SP *UNITED AIRLINES,25,debit,Travel,Flight,
+messy-variants.csv,SP *UNITED AIRLINES #7701,25,debit,Travel,Flight,
+messy-variants.csv,MARRIOTT #456,25,debit,Travel,Hotel,
+messy-variants.csv,MARRIOTT SEATTLE WA,25,debit,Travel,Hotel,
+messy-variants.csv,POS DEBIT SQ *MARRIOTT,25,debit,Travel,Hotel,
+messy-variants.csv,SQ *MARRIOTT #456,25,debit,Travel,Hotel,
+messy-variants.csv,HILTON #9012,25,debit,Travel,Hotel,
+messy-variants.csv,HILTON CHICAGO IL,25,debit,Travel,Hotel,
+messy-variants.csv,RECURRING PAYMENT TST* HILTON,25,debit,Travel,Hotel,
+messy-variants.csv,TST* HILTON #9012,25,debit,Travel,Hotel,
+messy-variants.csv,AIRBNB #214,25,debit,Travel,Vacation Rental,
+messy-variants.csv,AIRBNB PHOENIX AZ,25,debit,Travel,Vacation Rental,
+messy-variants.csv,CHECKCARD PAYPAL *AIRBNB,25,debit,Travel,Vacation Rental,
+messy-variants.csv,PAYPAL *AIRBNB #214,25,debit,Travel,Vacation Rental,
+messy-variants.csv,HERTZ RENT A CAR #6689,25,debit,Travel,Car Rental,
+messy-variants.csv,HERTZ RENT A CAR BOSTON MA,25,debit,Travel,Car Rental,
+messy-variants.csv,DEBIT CARD PURCHASE SP *HERTZ RENT A CAR,25,debit,Travel,Car Rental,
+messy-variants.csv,SP *HERTZ RENT A CAR #6689,25,debit,Travel,Car Rental,
+messy-variants.csv,PG&E ELECTRIC #1024,25,debit,Housing,Utilities,
+messy-variants.csv,PG&E ELECTRIC SAN LUIS OBISPO CA,25,debit,Housing,Utilities,
+messy-variants.csv,POS DEBIT SQ *PG&E ELECTRIC,25,debit,Housing,Utilities,
+messy-variants.csv,SQ *PG&E ELECTRIC #1024,25,debit,Housing,Utilities,
+messy-variants.csv,COMCAST XFINITY #5578,25,debit,Housing,Internet/Cable,
+messy-variants.csv,COMCAST XFINITY AUSTIN TX,25,debit,Housing,Internet/Cable,
+messy-variants.csv,RECURRING PAYMENT TST* COMCAST XFINITY,25,debit,Housing,Internet/Cable,
+messy-variants.csv,TST* COMCAST XFINITY #5578,25,debit,Housing,Internet/Cable,
+messy-variants.csv,AT&T WIRELESS #219,25,debit,Housing,Phone Bill,
+messy-variants.csv,AT&T WIRELESS BROOKLYN NY,25,debit,Housing,Phone Bill,
+messy-variants.csv,CHECKCARD PAYPAL *AT&T WIRELESS,25,debit,Housing,Phone Bill,
+messy-variants.csv,PAYPAL *AT&T WIRELESS #219,25,debit,Housing,Phone Bill,
+messy-variants.csv,VERIZON WIRELESS #8842,25,debit,Housing,Phone Bill,
+messy-variants.csv,VERIZON WIRELESS PORTLAND OR,25,debit,Housing,Phone Bill,
+messy-variants.csv,DEBIT CARD PURCHASE SP *VERIZON WIRELESS,25,debit,Housing,Phone Bill,
+messy-variants.csv,SP *VERIZON WIRELESS #8842,25,debit,Housing,Phone Bill,
+messy-variants.csv,BRIGHT HORIZONS #33,25,debit,Childcare,Daycare,
+messy-variants.csv,BRIGHT HORIZONS DENVER CO,25,debit,Childcare,Daycare,
+messy-variants.csv,POS DEBIT SQ *BRIGHT HORIZONS,25,debit,Childcare,Daycare,
+messy-variants.csv,SQ *BRIGHT HORIZONS #33,25,debit,Childcare,Daycare,
+messy-variants.csv,KINDERCARE #7701,25,debit,Childcare,Daycare,
+messy-variants.csv,KINDERCARE MIAMI FL,25,debit,Childcare,Daycare,
+messy-variants.csv,RECURRING PAYMENT TST* KINDERCARE,25,debit,Childcare,Daycare,
+messy-variants.csv,TST* KINDERCARE #7701,25,debit,Childcare,Daycare,
+messy-variants.csv,MONTESSORI ACADEMY #456,25,debit,Childcare,Preschool,
+messy-variants.csv,MONTESSORI ACADEMY SEATTLE WA,25,debit,Childcare,Preschool,
+messy-variants.csv,CHECKCARD PAYPAL *MONTESSORI ACADEMY,25,debit,Childcare,Preschool,
+messy-variants.csv,PAYPAL *MONTESSORI ACADEMY #456,25,debit,Childcare,Preschool,
+messy-variants.csv,NAVIENT STUDENT LOAN #9012,25,debit,Education,Student Loan,
+messy-variants.csv,NAVIENT STUDENT LOAN CHICAGO IL,25,debit,Education,Student Loan,
+messy-variants.csv,DEBIT CARD PURCHASE SP *NAVIENT STUDENT LOAN,25,debit,Education,Student Loan,
+messy-variants.csv,SP *NAVIENT STUDENT LOAN #9012,25,debit,Education,Student Loan,
+messy-variants.csv,KUMON MATH CENTER #214,25,debit,Education,Tutoring,
+messy-variants.csv,KUMON MATH CENTER PHOENIX AZ,25,debit,Education,Tutoring,
+messy-variants.csv,POS DEBIT SQ *KUMON MATH CENTER,25,debit,Education,Tutoring,
+messy-variants.csv,SQ *KUMON MATH CENTER #214,25,debit,Education,Tutoring,
+messy-variants.csv,COURSERA #6689,25,debit,Education,Online Course,
+messy-variants.csv,COURSERA BOSTON MA,25,debit,Education,Online Course,
+messy-variants.csv,RECURRING PAYMENT TST* COURSERA,25,debit,Education,Online Course,
+messy-variants.csv,TST* COURSERA #6689,25,debit,Education,Online Course,
+messy-variants.csv,VENMO #1024,25,debit,Transfer,Transfer,
+messy-variants.csv,VENMO SAN LUIS OBISPO CA,25,debit,Transfer,Transfer,
+messy-variants.csv,CHECKCARD PAYPAL *VENMO,25,debit,Transfer,Transfer,
+messy-variants.csv,PAYPAL *VENMO #1024,25,debit,Transfer,Transfer,
+messy-variants.csv,ZELLE #5578,25,debit,Transfer,Transfer,
+messy-variants.csv,ZELLE AUSTIN TX,25,debit,Transfer,Transfer,
+messy-variants.csv,DEBIT CARD PURCHASE SP *ZELLE,25,debit,Transfer,Transfer,
+messy-variants.csv,SP *ZELLE #5578,25,debit,Transfer,Transfer,
+messy-variants.csv,DIRECT DEPOSIT PAYROLL #219,25,credit,Income,Payroll,
+messy-variants.csv,DIRECT DEPOSIT PAYROLL BROOKLYN NY,25,credit,Income,Payroll,
+messy-variants.csv,POS DEBIT SQ *DIRECT DEPOSIT PAYROLL,25,credit,Income,Payroll,
+messy-variants.csv,SQ *DIRECT DEPOSIT PAYROLL #219,25,credit,Income,Payroll,
+messy-variants.csv,ADP PAYROLL #8842,25,credit,Income,Payroll,
+messy-variants.csv,ADP PAYROLL PORTLAND OR,25,credit,Income,Payroll,
+messy-variants.csv,RECURRING PAYMENT TST* ADP PAYROLL,25,credit,Income,Payroll,
+messy-variants.csv,TST* ADP PAYROLL #8842,25,credit,Income,Payroll,
+messy-variants.csv,INTEREST PAYMENT #33,25,credit,Income,Interest,
+messy-variants.csv,INTEREST PAYMENT DENVER CO,25,credit,Income,Interest,
+messy-variants.csv,CHECKCARD PAYPAL *INTEREST PAYMENT,25,credit,Income,Interest,
+messy-variants.csv,PAYPAL *INTEREST PAYMENT #33,25,credit,Income,Interest,
+messy-variants.csv,OAKWOOD APTS RENT #7701,25,debit,Housing,Rent,
+messy-variants.csv,OAKWOOD APTS RENT MIAMI FL,25,debit,Housing,Rent,
+messy-variants.csv,DEBIT CARD PURCHASE SP *OAKWOOD APTS RENT,25,debit,Housing,Rent,
+messy-variants.csv,SP *OAKWOOD APTS RENT #7701,25,debit,Housing,Rent,
+messy-variants.csv,GOLDEN GYM FITNESS #456,25,debit,Health,Gym,
+messy-variants.csv,GOLDEN GYM FITNESS SEATTLE WA,25,debit,Health,Gym,
+messy-variants.csv,POS DEBIT SQ *GOLDEN GYM FITNESS,25,debit,Health,Gym,
+messy-variants.csv,SQ *GOLDEN GYM FITNESS #456,25,debit,Health,Gym,
+messy-variants.csv,RIVERVIEW MEDICAL CLINIC #9012,25,debit,Health,Doctor/Medical,
+messy-variants.csv,RIVERVIEW MEDICAL CLINIC CHICAGO IL,25,debit,Health,Doctor/Medical,
+messy-variants.csv,RECURRING PAYMENT TST* RIVERVIEW MEDICAL CLINIC,25,debit,Health,Doctor/Medical,
+messy-variants.csv,TST* RIVERVIEW MEDICAL CLINIC #9012,25,debit,Health,Doctor/Medical,
+messy-variants.csv,HOPE CHARITY DONATION #214,25,debit,Other,Donation,
+messy-variants.csv,HOPE CHARITY DONATION PHOENIX AZ,25,debit,Other,Donation,
+messy-variants.csv,CHECKCARD PAYPAL *HOPE CHARITY DONATION,25,debit,Other,Donation,
+messy-variants.csv,PAYPAL *HOPE CHARITY DONATION #214,25,debit,Other,Donation,
+messy-variants.csv,MAPLEWOOD PROPERTY MANAGEMENT #6689,25,debit,Housing,Rent,
+messy-variants.csv,MAPLEWOOD PROPERTY MANAGEMENT BOSTON MA,25,debit,Housing,Rent,
+messy-variants.csv,DEBIT CARD PURCHASE SP *MAPLEWOOD PROPERTY MANAGEMENT,25,debit,Housing,Rent,
+messy-variants.csv,SP *MAPLEWOOD PROPERTY MANAGEMENT #6689,25,debit,Housing,Rent,

--- a/scripts/generate-golden-corpus.ts
+++ b/scripts/generate-golden-corpus.ts
@@ -36,6 +36,8 @@ interface GoldCsvRow {
   type: 'debit' | 'credit'
   category: Category
   subcategory: string
+  /** Raw bank-provided category column, when the fixture carries one (§4 PR-5) */
+  bankCategory?: string
 }
 
 const SAMPLE_DIR = resolve(__dirname, '../sample-data')
@@ -264,6 +266,7 @@ function buildFixtureRows(): GoldCsvRow[] {
         type: tx.type,
         category: label.category,
         subcategory: label.subcategory,
+        ...(tx.bankCategory ? { bankCategory: tx.bankCategory } : {}),
       })
     }
   }
@@ -454,7 +457,7 @@ function buildMessyVariantRows(): GoldCsvRow[] {
 // ---------------------------------------------------------------------------
 
 function writeCsv(filename: string, rows: GoldCsvRow[]): void {
-  const csv = Papa.unparse(rows, { columns: ['sourceFile', 'description', 'amount', 'type', 'category', 'subcategory'] })
+  const csv = Papa.unparse(rows, { columns: ['sourceFile', 'description', 'amount', 'type', 'category', 'subcategory', 'bankCategory'] })
   writeFileSync(resolve(OUT_DIR, filename), csv + '\n', 'utf8')
   console.log(`Wrote ${rows.length} rows to sample-data/labeled/${filename}`)
 }

--- a/src/hooks/useCategorization.test.ts
+++ b/src/hooks/useCategorization.test.ts
@@ -63,6 +63,27 @@ describe('useCategorization — offline-first classification', () => {
     expect(after?.subcategory).toBe(before.subcategory)
   })
 
+  it('harvests bank-provided categories for merchants unknown to the dictionary (§4 PR-5)', async () => {
+    const { result } = renderHook(() => useCategorization(''))
+
+    await act(async () => {
+      await result.current.handleFiles([loadSampleFile('monzo-uk.csv')])
+    })
+
+    // Bare "Amazon" (no ".COM"/"MKTP" suffix) doesn't match any merchantLookup rule, but
+    // monzo-uk.csv's own Category column says "Shopping" for it.
+    const amazon = result.current.allTransactions.find((tx) => tx.description === 'Amazon')
+    expect(amazon).toBeDefined()
+    expect(amazon?.category).toBe('Shopping')
+    expect(amazon?.subcategory).toBe('Shopping')
+    expect(amazon?.source).toBe('bank')
+
+    // Known merchants classified by the dictionary must NOT be tagged with a bank source.
+    const tesco = result.current.allTransactions.find((tx) => tx.description.includes('Tesco Express'))
+    expect(tesco?.category).toBe('Groceries')
+    expect(tesco?.source).toBeUndefined()
+  })
+
   it('never touches the network while classifying offline', async () => {
     const fetchSpy = vi.fn(() => Promise.reject(new Error('unexpected network request in test')))
     vi.stubGlobal('fetch', fetchSpy)

--- a/src/hooks/useCategorization.test.ts
+++ b/src/hooks/useCategorization.test.ts
@@ -98,4 +98,50 @@ describe('useCategorization — offline-first classification', () => {
       vi.unstubAllGlobals()
     }
   })
+
+  it('clears the bank source tag when a mode-change re-run overwrites it with a Claude result', async () => {
+    vi.doMock('../lib/categorize', () => ({
+      categorizeTransactions: vi.fn(async (transactions: { id: string }[]) =>
+        transactions.map((tx) => ({ id: tx.id, category: 'Shopping', subcategory: 'Online shopping' })),
+      ),
+    }))
+    try {
+      const { result } = renderHook(() => useCategorization('sk-ant-test-key'))
+
+      // monzo-uk.csv alone is fully covered by the offline layers (dictionary + bank
+      // harvesting), so it never reaches Claude on its own. bofa-credit-card.csv has a
+      // genuine offline miss (see the "gates the Claude button" test above), which forces
+      // the first handleCategorize call to actually run and record lastCategorizedMode —
+      // required for a later mode switch to be recognized as a mode-change re-run.
+      await act(async () => {
+        await result.current.handleFiles([loadSampleFile('monzo-uk.csv'), loadSampleFile('bofa-credit-card.csv')])
+      })
+
+      const amazon = result.current.allTransactions.find((tx) => tx.description === 'Amazon')
+      expect(amazon?.source).toBe('bank')
+
+      await act(async () => {
+        await result.current.handleCategorize()
+      })
+      expect(result.current.lastCategorizedMode).toBe('simple')
+      expect(result.current.allTransactions.find((tx) => tx.description === 'Amazon')?.source).toBe('bank')
+
+      // Now switch modes and re-run — a mode-change run resends ALL non-Transfer
+      // transactions to Claude, including the already bank-categorized Amazon row.
+      act(() => {
+        result.current.setCategorizationMode('detailed')
+      })
+
+      await act(async () => {
+        await result.current.handleCategorize()
+      })
+
+      const reCategorized = result.current.allTransactions.find((tx) => tx.description === 'Amazon')
+      expect(reCategorized?.category).toBe('Shopping')
+      expect(reCategorized?.subcategory).toBe('Online shopping')
+      expect(reCategorized?.source).toBeUndefined()
+    } finally {
+      vi.doUnmock('../lib/categorize')
+    }
+  })
 })

--- a/src/hooks/useCategorization.ts
+++ b/src/hooks/useCategorization.ts
@@ -134,7 +134,7 @@ export function useCategorization(apiKey: string): CategorizationState {
             if (tx.category === 'Transfer' || tx.subcategory !== '') return tx
             const match = classifyByMerchant(tx.description, tx.type)
             if (match) return { ...tx, category: match.category, subcategory: match.subcategory }
-            const bankMatch = classifyByBankCategory(tx.bankCategory)
+            const bankMatch = classifyByBankCategory(tx.bankCategory, tx.type)
             if (bankMatch) {
               return { ...tx, category: bankMatch.category, subcategory: bankMatch.subcategory, source: bankMatch.source }
             }
@@ -192,7 +192,7 @@ export function useCategorization(apiKey: string): CategorizationState {
             if (tx.category === 'Transfer') return tx
             const result = resultMap.get(tx.id)
             if (!result) return tx
-            return { ...tx, category: result.category, subcategory: result.subcategory }
+            return { ...tx, category: result.category, subcategory: result.subcategory, source: undefined }
           }),
         })),
       )

--- a/src/hooks/useCategorization.ts
+++ b/src/hooks/useCategorization.ts
@@ -5,6 +5,7 @@ import { readCsvFile } from '../lib/readCsv'
 import { detectFormat, parseTransactions } from '../lib/parser'
 import { detectTransfers } from '../lib/transfers'
 import { classifyByMerchant } from '../lib/merchantLookup'
+import { classifyByBankCategory } from '../lib/bankCategory'
 
 let fileCounter = 0
 
@@ -121,16 +122,23 @@ export function useCategorization(apiKey: string): CategorizationState {
         const allTx = next.flatMap((f) => f.transactions)
         const transferIds = detectTransfers(allTx)
 
-        // Free, key-free offline layers — transfer detection above, and merchant lookup
-        // here — run unconditionally so a Sankey can render before any API key exists
-        // (docs/classification-improvement-fable.md §2.C, docs/product-review-fable.md §5 PR-2).
+        // Free, key-free offline layers — transfer detection, merchant lookup, and bank-
+        // provided category harvesting (docs/classification-improvement-fable.md §2.C/§2.D,
+        // §4 PR-3/PR-5) — run unconditionally so a Sankey can render before any API key
+        // exists. Bank category only applies when the merchant dictionary doesn't already
+        // know the merchant — it's a mid-confidence hint, not truth.
         return next.map((file) => ({
           ...file,
           transactions: file.transactions.map((tx) => {
             if (transferIds.has(tx.id)) return { ...tx, category: 'Transfer' }
             if (tx.category === 'Transfer' || tx.subcategory !== '') return tx
             const match = classifyByMerchant(tx.description, tx.type)
-            return match ? { ...tx, category: match.category, subcategory: match.subcategory } : tx
+            if (match) return { ...tx, category: match.category, subcategory: match.subcategory }
+            const bankMatch = classifyByBankCategory(tx.bankCategory)
+            if (bankMatch) {
+              return { ...tx, category: bankMatch.category, subcategory: bankMatch.subcategory, source: bankMatch.source }
+            }
+            return tx
           }),
         }))
       })

--- a/src/lib/bankCategory.test.ts
+++ b/src/lib/bankCategory.test.ts
@@ -3,7 +3,7 @@ import { classifyByBankCategory } from './bankCategory'
 
 describe('classifyByBankCategory', () => {
   it('classifies a Monzo-style bank category', () => {
-    expect(classifyByBankCategory('Groceries')).toEqual({
+    expect(classifyByBankCategory('Groceries', 'debit')).toEqual({
       category: 'Groceries',
       subcategory: 'Groceries',
       source: 'bank',
@@ -11,12 +11,12 @@ describe('classifyByBankCategory', () => {
   })
 
   it('classifies via the alias table (Monzo "Eating out", Chase "Food & Drink")', () => {
-    expect(classifyByBankCategory('Eating out')).toEqual({
+    expect(classifyByBankCategory('Eating out', 'debit')).toEqual({
       category: 'Dining',
       subcategory: 'Eating out',
       source: 'bank',
     })
-    expect(classifyByBankCategory('Food & Drink')).toEqual({
+    expect(classifyByBankCategory('Food & Drink', 'debit')).toEqual({
       category: 'Groceries',
       subcategory: 'Food & Drink',
       source: 'bank',
@@ -24,7 +24,7 @@ describe('classifyByBankCategory', () => {
   })
 
   it('trims whitespace before resolving and for the returned subcategory', () => {
-    expect(classifyByBankCategory('  Shopping  ')).toEqual({
+    expect(classifyByBankCategory('  Shopping  ', 'debit')).toEqual({
       category: 'Shopping',
       subcategory: 'Shopping',
       source: 'bank',
@@ -32,13 +32,26 @@ describe('classifyByBankCategory', () => {
   })
 
   it('returns null for undefined, empty, or whitespace-only input', () => {
-    expect(classifyByBankCategory(undefined)).toBeNull()
-    expect(classifyByBankCategory('')).toBeNull()
-    expect(classifyByBankCategory('   ')).toBeNull()
+    expect(classifyByBankCategory(undefined, 'debit')).toBeNull()
+    expect(classifyByBankCategory('', 'debit')).toBeNull()
+    expect(classifyByBankCategory('   ', 'debit')).toBeNull()
   })
 
   it('returns null for bank vocabulary with no home in the taxonomy (e.g. Chase "Charity")', () => {
-    expect(classifyByBankCategory('Charity')).toBeNull()
-    expect(classifyByBankCategory('Tax')).toBeNull()
+    expect(classifyByBankCategory('Charity', 'debit')).toBeNull()
+    expect(classifyByBankCategory('Tax', 'debit')).toBeNull()
+  })
+
+  it('classifies an Income-mapped bank category on a credit', () => {
+    expect(classifyByBankCategory('Interest', 'credit')).toEqual({
+      category: 'Income',
+      subcategory: 'Interest',
+      source: 'bank',
+    })
+  })
+
+  it('returns null for an Income-mapped bank category on a debit (e.g. interest charged, not earned)', () => {
+    expect(classifyByBankCategory('Interest', 'debit')).toBeNull()
+    expect(classifyByBankCategory('Deposit', 'debit')).toBeNull()
   })
 })

--- a/src/lib/bankCategory.test.ts
+++ b/src/lib/bankCategory.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { classifyByBankCategory } from './bankCategory'
+
+describe('classifyByBankCategory', () => {
+  it('classifies a Monzo-style bank category', () => {
+    expect(classifyByBankCategory('Groceries')).toEqual({
+      category: 'Groceries',
+      subcategory: 'Groceries',
+      source: 'bank',
+    })
+  })
+
+  it('classifies via the alias table (Monzo "Eating out", Chase "Food & Drink")', () => {
+    expect(classifyByBankCategory('Eating out')).toEqual({
+      category: 'Dining',
+      subcategory: 'Eating out',
+      source: 'bank',
+    })
+    expect(classifyByBankCategory('Food & Drink')).toEqual({
+      category: 'Groceries',
+      subcategory: 'Food & Drink',
+      source: 'bank',
+    })
+  })
+
+  it('trims whitespace before resolving and for the returned subcategory', () => {
+    expect(classifyByBankCategory('  Shopping  ')).toEqual({
+      category: 'Shopping',
+      subcategory: 'Shopping',
+      source: 'bank',
+    })
+  })
+
+  it('returns null for undefined, empty, or whitespace-only input', () => {
+    expect(classifyByBankCategory(undefined)).toBeNull()
+    expect(classifyByBankCategory('')).toBeNull()
+    expect(classifyByBankCategory('   ')).toBeNull()
+  })
+
+  it('returns null for bank vocabulary with no home in the taxonomy (e.g. Chase "Charity")', () => {
+    expect(classifyByBankCategory('Charity')).toBeNull()
+    expect(classifyByBankCategory('Tax')).toBeNull()
+  })
+})

--- a/src/lib/bankCategory.ts
+++ b/src/lib/bankCategory.ts
@@ -22,15 +22,21 @@ export interface BankCategoryClassification {
 /**
  * Translate a bank's own category label to our taxonomy. Returns null when the bank
  * category is missing or has no home in the taxonomy (e.g. Chase's "Charity", "Tax") —
- * never guesses.
+ * never guesses. Also returns null when the alias resolves to Income on a debit (e.g. a
+ * bank's "Interest" label meaning interest charged, not earned) — Sankey buckets debits
+ * as expenses, so that combination would render an expense-side "Income" node.
  */
-export function classifyByBankCategory(bankCategory: string | undefined): BankCategoryClassification | null {
+export function classifyByBankCategory(
+  bankCategory: string | undefined,
+  type: 'debit' | 'credit',
+): BankCategoryClassification | null {
   if (!bankCategory) return null
   const trimmed = bankCategory.trim()
   if (!trimmed) return null
 
   const category = resolveCategoryAlias(trimmed)
   if (!category) return null
+  if (category === 'Income' && type === 'debit') return null
 
   return { category, subcategory: trimmed, source: 'bank' }
 }

--- a/src/lib/bankCategory.ts
+++ b/src/lib/bankCategory.ts
@@ -1,0 +1,36 @@
+/**
+ * Bank-provided category harvesting — a free, key-free classification layer that reads
+ * the Category-like column some banks already export (Chase's "Food & Drink", Monzo's
+ * "Groceries") instead of discarding it (docs/classification-improvement-fable.md §2.D
+ * / §4 PR-5).
+ *
+ * Mid-confidence hint, not truth — a bank's own categorization is sometimes wrong (see
+ * scripts/generate-golden-corpus.ts's FIXTURE_GOLD comment), so this only fires when the
+ * merchant dictionary (merchantLookup.ts) doesn't already know the merchant. Consumers:
+ * useCategorization.ts:handleFiles (Layer 4, after the merchant dictionary misses) and
+ * evaluate.ts (the offline eval harness).
+ */
+import type { Category } from './types'
+import { resolveCategoryAlias } from './categoryAliases'
+
+export interface BankCategoryClassification {
+  category: Category
+  subcategory: string
+  source: 'bank'
+}
+
+/**
+ * Translate a bank's own category label to our taxonomy. Returns null when the bank
+ * category is missing or has no home in the taxonomy (e.g. Chase's "Charity", "Tax") —
+ * never guesses.
+ */
+export function classifyByBankCategory(bankCategory: string | undefined): BankCategoryClassification | null {
+  if (!bankCategory) return null
+  const trimmed = bankCategory.trim()
+  if (!trimmed) return null
+
+  const category = resolveCategoryAlias(trimmed)
+  if (!category) return null
+
+  return { category, subcategory: trimmed, source: 'bank' }
+}

--- a/src/lib/categorize.ts
+++ b/src/lib/categorize.ts
@@ -1,8 +1,8 @@
 import Anthropic from '@anthropic-ai/sdk'
 import type { Transaction } from './types'
-import { CATEGORIES } from './types'
 import { getCached, setCached } from './categorizationCache'
 import { classifyByMerchant } from './merchantLookup'
+import { resolveCategoryAlias } from './categoryAliases'
 
 interface CategorizationResult {
   id: string
@@ -138,73 +138,8 @@ IMPORTANT: Respond ONLY with a valid JSON array. No markdown, no explanation, no
 const BATCH_SIZE = 50
 const CONCURRENCY = 5
 
-const VALID_CATEGORIES = new Set<string>(CATEGORIES)
-
-/** Map fuzzy/variant category names Claude sometimes returns to our canonical set */
-const CATEGORY_ALIASES: Record<string, string> = {
-  // Groceries
-  grocery: 'Groceries', supermarket: 'Groceries', 'grocery store': 'Groceries',
-  'warehouse grocery': 'Groceries', 'grocery delivery': 'Groceries',
-  food: 'Groceries',  // generic "Food" → Groceries as the safer default
-  'food & drink': 'Groceries', 'food and drink': 'Groceries',
-  // Dining
-  dining: 'Dining', restaurant: 'Dining', restaurants: 'Dining',
-  'dining out': 'Dining', 'eating out': 'Dining',
-  'coffee shop': 'Dining', 'coffee shops': 'Dining', coffee: 'Dining',
-  'food delivery': 'Dining', takeout: 'Dining', takeaway: 'Dining',
-  'fast food': 'Dining',
-  // Transport
-  gas: 'Transport', transportation: 'Transport', transit: 'Transport',
-  rideshare: 'Transport', 'car insurance': 'Transport', parking: 'Transport',
-  fuel: 'Transport', 'public transit': 'Transport',
-  // Travel
-  travel: 'Travel', hotel: 'Travel', hotels: 'Travel',
-  airline: 'Travel', airlines: 'Travel', flight: 'Travel', flights: 'Travel',
-  accommodation: 'Travel', lodging: 'Travel', vacation: 'Travel',
-  // Shopping
-  retail: 'Shopping', 'online shopping': 'Shopping', clothing: 'Shopping',
-  electronics: 'Shopping', merchandise: 'Shopping', 'online retail': 'Shopping',
-  // Entertainment
-  entertainment: 'Entertainment', games: 'Entertainment', gaming: 'Entertainment',
-  movies: 'Entertainment', concerts: 'Entertainment', sports: 'Entertainment',
-  streaming: 'Subscriptions', alcohol: 'Entertainment',
-  // Health
-  medical: 'Health', healthcare: 'Health', pharmacy: 'Health',
-  fitness: 'Health', gym: 'Health', dental: 'Health',
-  // Subscriptions
-  subscription: 'Subscriptions', subscriptions: 'Subscriptions',
-  'streaming services': 'Subscriptions', 'recurring services': 'Subscriptions',
-  'ai api service': 'Subscriptions', saas: 'Subscriptions',
-  // Childcare
-  childcare: 'Childcare', daycare: 'Childcare', 'child care': 'Childcare',
-  preschool: 'Childcare', 'pre-school': 'Childcare', 'after school': 'Childcare',
-  'summer camp': 'Childcare', nanny: 'Childcare', babysitter: 'Childcare',
-  'dependent care': 'Childcare',
-  // Education
-  education: 'Education', tuition: 'Education', 'school tuition': 'Education',
-  'student loan': 'Education', 'student loans': 'Education',
-  tutoring: 'Education', 'online course': 'Education', 'online learning': 'Education',
-  'test prep': 'Education', university: 'Education', college: 'Education',
-  // Housing
-  housing: 'Housing', rent: 'Housing', mortgage: 'Housing',
-  utilities: 'Housing', utility: 'Housing', insurance: 'Housing',
-  'phone bill': 'Housing', 'utility bill': 'Housing', 'electric bill': 'Housing',
-  // Income
-  income: 'Income', salary: 'Income', payroll: 'Income',
-  wages: 'Income', deposit: 'Income', 'side job': 'Income',
-  // Transfer
-  transfer: 'Transfer', transfers: 'Transfer',
-  // Other
-  miscellaneous: 'Other', misc: 'Other',
-}
-
 function normalizeCategory(raw: string): string {
-  if (VALID_CATEGORIES.has(raw)) return raw
-  const lower = raw.toLowerCase().trim()
-  if (VALID_CATEGORIES.has(lower.charAt(0).toUpperCase() + lower.slice(1))) {
-    return lower.charAt(0).toUpperCase() + lower.slice(1)
-  }
-  return CATEGORY_ALIASES[lower] ?? 'Other'
+  return resolveCategoryAlias(raw) ?? 'Other'
 }
 
 /** Clamp a Claude-returned subcategory to the taxonomy list for detailed mode.

--- a/src/lib/categoryAliases.test.ts
+++ b/src/lib/categoryAliases.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveCategoryAlias, CATEGORY_ALIASES } from './categoryAliases'
-import { CATEGORIES } from './types'
+import { resolveCategoryAlias } from './categoryAliases'
 
 describe('resolveCategoryAlias', () => {
   it('resolves an exact canonical category unchanged', () => {
@@ -32,12 +31,5 @@ describe('resolveCategoryAlias', () => {
     expect(resolveCategoryAlias('Charity')).toBeNull()
     expect(resolveCategoryAlias('Tax')).toBeNull()
     expect(resolveCategoryAlias('Something Totally Unrecognized')).toBeNull()
-  })
-
-  it('every alias value is a real taxonomy category', () => {
-    const valid = new Set<string>(CATEGORIES)
-    for (const [alias, category] of Object.entries(CATEGORY_ALIASES)) {
-      expect(valid.has(category), `alias "${alias}" -> "${category}" is not a valid Category`).toBe(true)
-    }
   })
 })

--- a/src/lib/categoryAliases.test.ts
+++ b/src/lib/categoryAliases.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { resolveCategoryAlias, CATEGORY_ALIASES } from './categoryAliases'
+import { CATEGORIES } from './types'
+
+describe('resolveCategoryAlias', () => {
+  it('resolves an exact canonical category unchanged', () => {
+    expect(resolveCategoryAlias('Groceries')).toBe('Groceries')
+    expect(resolveCategoryAlias('Transfer')).toBe('Transfer')
+  })
+
+  it('resolves a differently-cased canonical category', () => {
+    expect(resolveCategoryAlias('groceries')).toBe('Groceries')
+    expect(resolveCategoryAlias('SHOPPING')).toBe('Shopping')
+  })
+
+  it('resolves known bank/Claude vocabulary through the alias table', () => {
+    expect(resolveCategoryAlias('Food & Drink')).toBe('Groceries')
+    expect(resolveCategoryAlias('Eating out')).toBe('Dining')
+    expect(resolveCategoryAlias('Transfers')).toBe('Transfer')
+    expect(resolveCategoryAlias('Home')).toBe('Housing')
+    expect(resolveCategoryAlias('Bills & Utilities')).toBe('Housing')
+    expect(resolveCategoryAlias('Health & Wellness')).toBe('Health')
+    expect(resolveCategoryAlias('Interest')).toBe('Income')
+    expect(resolveCategoryAlias('Payroll')).toBe('Income')
+  })
+
+  it('is case-insensitive and trims whitespace for alias lookups', () => {
+    expect(resolveCategoryAlias('  EATING OUT  ')).toBe('Dining')
+  })
+
+  it('returns null for vocabulary with no home in the taxonomy, rather than guessing', () => {
+    expect(resolveCategoryAlias('Charity')).toBeNull()
+    expect(resolveCategoryAlias('Tax')).toBeNull()
+    expect(resolveCategoryAlias('Something Totally Unrecognized')).toBeNull()
+  })
+
+  it('every alias value is a real taxonomy category', () => {
+    const valid = new Set<string>(CATEGORIES)
+    for (const [alias, category] of Object.entries(CATEGORY_ALIASES)) {
+      expect(valid.has(category), `alias "${alias}" -> "${category}" is not a valid Category`).toBe(true)
+    }
+  })
+})

--- a/src/lib/categoryAliases.ts
+++ b/src/lib/categoryAliases.ts
@@ -1,0 +1,91 @@
+/**
+ * Fuzzy/variant category vocabulary -> canonical taxonomy category.
+ *
+ * Shared by categorize.ts (normalizing Claude's free-form category responses) and
+ * bankCategory.ts (harvesting bank-provided category columns, docs/classification-
+ * improvement-fable.md §2.D / §4 PR-5) so both resolve the same vocabulary the same way.
+ * Lives outside categorize.ts specifically so it has no @anthropic-ai/sdk import — this
+ * module needs to be safe to import eagerly (bankCategory.ts runs unconditionally in
+ * useCategorization.ts's handleFiles, no API key required).
+ */
+import { CATEGORIES, type Category } from './types'
+
+export const CATEGORY_ALIASES: Record<string, string> = {
+  // Groceries
+  grocery: 'Groceries', supermarket: 'Groceries', 'grocery store': 'Groceries',
+  'warehouse grocery': 'Groceries', 'grocery delivery': 'Groceries',
+  food: 'Groceries',  // generic "Food" → Groceries as the safer default
+  'food & drink': 'Groceries', 'food and drink': 'Groceries',
+  // Dining
+  dining: 'Dining', restaurant: 'Dining', restaurants: 'Dining',
+  'dining out': 'Dining', 'eating out': 'Dining',
+  'coffee shop': 'Dining', 'coffee shops': 'Dining', coffee: 'Dining',
+  'food delivery': 'Dining', takeout: 'Dining', takeaway: 'Dining',
+  'fast food': 'Dining',
+  // Transport
+  gas: 'Transport', transportation: 'Transport', transit: 'Transport',
+  rideshare: 'Transport', 'car insurance': 'Transport', parking: 'Transport',
+  fuel: 'Transport', 'public transit': 'Transport',
+  // Travel
+  travel: 'Travel', hotel: 'Travel', hotels: 'Travel',
+  airline: 'Travel', airlines: 'Travel', flight: 'Travel', flights: 'Travel',
+  accommodation: 'Travel', lodging: 'Travel', vacation: 'Travel',
+  // Shopping
+  retail: 'Shopping', 'online shopping': 'Shopping', clothing: 'Shopping',
+  electronics: 'Shopping', merchandise: 'Shopping', 'online retail': 'Shopping',
+  // Entertainment
+  entertainment: 'Entertainment', games: 'Entertainment', gaming: 'Entertainment',
+  movies: 'Entertainment', concerts: 'Entertainment', sports: 'Entertainment',
+  streaming: 'Subscriptions', alcohol: 'Entertainment',
+  // Health
+  medical: 'Health', healthcare: 'Health', pharmacy: 'Health',
+  fitness: 'Health', gym: 'Health', dental: 'Health',
+  'health & wellness': 'Health', 'health and wellness': 'Health',
+  // Subscriptions
+  subscription: 'Subscriptions', subscriptions: 'Subscriptions',
+  'streaming services': 'Subscriptions', 'recurring services': 'Subscriptions',
+  'ai api service': 'Subscriptions', saas: 'Subscriptions',
+  // Childcare
+  childcare: 'Childcare', daycare: 'Childcare', 'child care': 'Childcare',
+  preschool: 'Childcare', 'pre-school': 'Childcare', 'after school': 'Childcare',
+  'summer camp': 'Childcare', nanny: 'Childcare', babysitter: 'Childcare',
+  'dependent care': 'Childcare',
+  // Education
+  education: 'Education', tuition: 'Education', 'school tuition': 'Education',
+  'student loan': 'Education', 'student loans': 'Education',
+  tutoring: 'Education', 'online course': 'Education', 'online learning': 'Education',
+  'test prep': 'Education', university: 'Education', college: 'Education',
+  // Housing
+  housing: 'Housing', rent: 'Housing', mortgage: 'Housing', home: 'Housing',
+  utilities: 'Housing', utility: 'Housing', insurance: 'Housing',
+  'phone bill': 'Housing', 'utility bill': 'Housing', 'electric bill': 'Housing',
+  'bills & utilities': 'Housing', 'bills and utilities': 'Housing',
+  // Income
+  income: 'Income', salary: 'Income', payroll: 'Income', interest: 'Income',
+  wages: 'Income', deposit: 'Income', 'side job': 'Income',
+  // Transfer
+  transfer: 'Transfer', transfers: 'Transfer',
+  // Other
+  miscellaneous: 'Other', misc: 'Other',
+  // Deliberately unmapped: bank vocabularies with no home in the current taxonomy
+  // (e.g. Chase's "Charity", "Tax") fall through to null rather than a guessed category —
+  // see docs/classification-improvement-fable.md §1.4d, scoped out as a taxonomy follow-up.
+}
+
+const VALID_CATEGORIES = new Set<string>(CATEGORIES)
+
+/**
+ * Resolve a free-form category string (from Claude or a bank's own CSV column) to a
+ * canonical taxonomy Category. Returns null — not a guess — when nothing matches, so
+ * callers can tell "recognized" from "unrecognized" apart (categorize.ts's Claude
+ * normalizer falls back to 'Other' on null; bankCategory.ts's harvester treats null as
+ * "no signal" and leaves the transaction for a later layer).
+ */
+export function resolveCategoryAlias(raw: string): Category | null {
+  if (VALID_CATEGORIES.has(raw)) return raw as Category
+  const lower = raw.toLowerCase().trim()
+  const titled = lower.charAt(0).toUpperCase() + lower.slice(1)
+  if (VALID_CATEGORIES.has(titled)) return titled as Category
+  const alias = CATEGORY_ALIASES[lower]
+  return alias && VALID_CATEGORIES.has(alias) ? (alias as Category) : null
+}

--- a/src/lib/categoryAliases.ts
+++ b/src/lib/categoryAliases.ts
@@ -10,7 +10,7 @@
  */
 import { CATEGORIES, type Category } from './types'
 
-export const CATEGORY_ALIASES: Record<string, string> = {
+export const CATEGORY_ALIASES: Record<string, Category> = {
   // Groceries
   grocery: 'Groceries', supermarket: 'Groceries', 'grocery store': 'Groceries',
   'warehouse grocery': 'Groceries', 'grocery delivery': 'Groceries',
@@ -86,6 +86,5 @@ export function resolveCategoryAlias(raw: string): Category | null {
   const lower = raw.toLowerCase().trim()
   const titled = lower.charAt(0).toUpperCase() + lower.slice(1)
   if (VALID_CATEGORIES.has(titled)) return titled as Category
-  const alias = CATEGORY_ALIASES[lower]
-  return alias && VALID_CATEGORIES.has(alias) ? (alias as Category) : null
+  return CATEGORY_ALIASES[lower] ?? null
 }

--- a/src/lib/evaluate.test.ts
+++ b/src/lib/evaluate.test.ts
@@ -21,6 +21,7 @@ import {
   formatConfusionMatrix,
   merchantLookupClassifier,
   transferKeywordClassifier,
+  bankCategoryClassifier,
   combinedOfflineClassifier,
   type GoldTransaction,
 } from './evaluate'
@@ -45,6 +46,7 @@ function loadGoldCsv(filename: string): GoldTransaction[] {
       type: row.type as 'debit' | 'credit',
       category: row.category as Category,
       subcategory: row.subcategory,
+      ...(row.bankCategory ? { bankCategory: row.bankCategory } : {}),
     }
   })
 }
@@ -124,6 +126,12 @@ describe('offline classification eval harness', () => {
     // store-number/prefix rules, Shell/beach-city guard narrowed, ACH-credit/transfer guard) —
     // see sample-data/labeled/layer1-correct-baseline.json + the test below for the per-row
     // regression net this aggregate floor alone couldn't provide.
+    // Raised again by PR-5 (bank-provided category harvesting, §4 PR-5): the FIXTURE_/
+    // CORPUS_COMBINED_* floors below now include Layer 4 (bankCategoryClassifier), which
+    // recovers 34 rows (monzo-uk.csv's "EMPLOYER SALARY" and bare "Amazon" — unknown to the
+    // merchant dictionary, but carry a resolvable bank Category column) that Layer 0/1 alone
+    // both missed. The Layer 0/1-only floors are untouched — this layer is a fallback that
+    // only ever adds coverage on top of them, never competes with them.
     const FIXTURE_COVERAGE_FLOOR = 0.920 // measured 923/1003 = 92.02%
     const FIXTURE_ACCURACY_FLOOR = 0.996 // measured 920/923 = 99.67% (of covered fixture rows)
 
@@ -133,15 +141,24 @@ describe('offline classification eval harness', () => {
     const CORPUS_LAYER0_COVERAGE_FLOOR = 0.044 // measured 59/1333 = 4.43%
     const CORPUS_LAYER0_ACCURACY_FLOOR = 1.0 // measured 59/59 = 100%
 
-    const CORPUS_COMBINED_COVERAGE_FLOOR = 0.957 // measured 1277/1333 = 95.80%
-    const CORPUS_COMBINED_ACCURACY_FLOOR = 0.997 // measured 1274/1277 = 99.77%
+    // "Combined fixture coverage ... ≥ 93%" (§4 PR-5 acceptance) — measured on the 1003
+    // existing-fixture rows alone (no synthetic adversarial/messy-variant rows).
+    const FIXTURE_COMBINED_COVERAGE_FLOOR = 0.977 // measured 981/1003 = 97.81%
+    const FIXTURE_COMBINED_ACCURACY_FLOOR = 0.996 // measured 978/981 = 99.69%
+
+    const CORPUS_COMBINED_COVERAGE_FLOOR = 0.982 // measured 1311/1333 = 98.35%
+    const CORPUS_COMBINED_ACCURACY_FLOOR = 0.997 // measured 1308/1311 = 99.77%
 
     const fixtureLayer1 = evaluateLayer('Layer 1 — merchantLookup (existing fixtures only)', fixtureRows, merchantLookupClassifier)
+    const fixtureCombined = evaluateLayer('Combined — Layer 0+1+4 (existing fixtures only)', fixtureRows, combinedOfflineClassifier)
     const corpusLayer0 = evaluateLayer('Layer 0 — transfer keywords (full corpus)', allRows, transferKeywordClassifier)
     const corpusLayer1 = evaluateLayer('Layer 1 — merchantLookup (full corpus)', allRows, merchantLookupClassifier)
-    const corpusCombined = evaluateLayer('Combined — Layer 0 then Layer 1 (full corpus)', allRows, combinedOfflineClassifier)
+    const corpusLayer4 = evaluateLayer('Layer 4 — bank category (full corpus)', allRows, bankCategoryClassifier)
+    const corpusCombined = evaluateLayer('Combined — Layer 0+1+4 (full corpus)', allRows, combinedOfflineClassifier)
 
-    const reportTable = formatLayerReportTable([fixtureLayer1, corpusLayer0, corpusLayer1, corpusCombined])
+    const reportTable = formatLayerReportTable([
+      fixtureLayer1, fixtureCombined, corpusLayer0, corpusLayer1, corpusLayer4, corpusCombined,
+    ])
     const confusionMatrix = formatConfusionMatrix(buildConfusionMatrix(allRows, merchantLookupClassifier))
 
     console.log(`\nOffline classification baseline (sample-data/labeled/, ${allRows.length} rows):\n\n${reportTable}`)
@@ -149,6 +166,9 @@ describe('offline classification eval harness', () => {
 
     expect(fixtureLayer1.coverage).toBeGreaterThanOrEqual(FIXTURE_COVERAGE_FLOOR)
     expect(fixtureLayer1.accuracy).toBeGreaterThanOrEqual(FIXTURE_ACCURACY_FLOOR)
+
+    expect(fixtureCombined.coverage).toBeGreaterThanOrEqual(FIXTURE_COMBINED_COVERAGE_FLOOR)
+    expect(fixtureCombined.accuracy).toBeGreaterThanOrEqual(FIXTURE_COMBINED_ACCURACY_FLOOR)
 
     expect(corpusLayer1.coverage).toBeGreaterThanOrEqual(CORPUS_LAYER1_COVERAGE_FLOOR)
     expect(corpusLayer1.accuracy).toBeGreaterThanOrEqual(CORPUS_LAYER1_ACCURACY_FLOOR)

--- a/src/lib/evaluate.ts
+++ b/src/lib/evaluate.ts
@@ -10,6 +10,7 @@
  */
 import type { Category } from './types'
 import { classifyByMerchant } from './merchantLookup'
+import { classifyByBankCategory } from './bankCategory'
 import { detectTransfers } from './transfers'
 
 /** A single golden-corpus row: a transaction description with its correct category. */
@@ -20,6 +21,9 @@ export interface GoldTransaction {
   type: 'debit' | 'credit'
   category: Category
   subcategory: string
+  /** Raw bank-provided category column, when the source fixture carries one (currently
+   *  only chase-checking.csv and monzo-uk.csv — see lib/bankCategory.ts, §4 PR-5). */
+  bankCategory?: string
 }
 
 /** A classification layer under test: predicts a category from a gold row, or null (miss). */
@@ -84,9 +88,18 @@ export const transferKeywordClassifier: OfflineClassifier = (row) => {
   return transferIds.size > 0 ? 'Transfer' : null
 }
 
-/** Both zero-network layers, transfer detection first (matches the real pipeline order). */
+/**
+ * Layer 4 — bank-provided category harvesting (bankCategory.ts:classifyByBankCategory),
+ * evaluated as a merchant-dictionary fallback: only consulted when Layer 1 misses, same
+ * as the real pipeline (useCategorization.ts:handleFiles).
+ */
+export const bankCategoryClassifier: OfflineClassifier = (row) =>
+  classifyByBankCategory(row.bankCategory)?.category ?? null
+
+/** All zero-network layers, in real-pipeline order: transfers, then merchant dictionary,
+ *  then bank-provided category. */
 export const combinedOfflineClassifier: OfflineClassifier = (row) =>
-  transferKeywordClassifier(row) ?? merchantLookupClassifier(row)
+  transferKeywordClassifier(row) ?? merchantLookupClassifier(row) ?? bankCategoryClassifier(row)
 
 /** predicted category, or 'MISS' for an uncovered row */
 type PredictedKey = Category | 'MISS'

--- a/src/lib/evaluate.ts
+++ b/src/lib/evaluate.ts
@@ -90,11 +90,15 @@ export const transferKeywordClassifier: OfflineClassifier = (row) => {
 
 /**
  * Layer 4 — bank-provided category harvesting (bankCategory.ts:classifyByBankCategory),
- * evaluated as a merchant-dictionary fallback: only consulted when Layer 1 misses, same
- * as the real pipeline (useCategorization.ts:handleFiles).
+ * evaluated standalone over the full corpus — including rows Layer 1 (merchant
+ * dictionary) would have intercepted in the real pipeline. Its printed accuracy is
+ * therefore raw bank-column agreement with gold, not the pipeline's actual Layer-4
+ * accuracy; only combinedOfflineClassifier reflects real pipeline behavior (transfers,
+ * then merchant dictionary, then bank category, same order as
+ * useCategorization.ts:handleFiles).
  */
 export const bankCategoryClassifier: OfflineClassifier = (row) =>
-  classifyByBankCategory(row.bankCategory)?.category ?? null
+  classifyByBankCategory(row.bankCategory, row.type)?.category ?? null
 
 /** All zero-network layers, in real-pipeline order: transfers, then merchant dictionary,
  *  then bank-provided category. */

--- a/src/lib/parser.test.ts
+++ b/src/lib/parser.test.ts
@@ -36,6 +36,18 @@ describe('detectFormat', () => {
     expect(mapping.amount).toBe('Amount')
   })
 
+  it('detects a bank-provided Category column when present', () => {
+    const headers = ['Transaction Date', 'Post Date', 'Description', 'Category', 'Type', 'Amount', 'Memo']
+    const mapping = detectFormat(headers, [])
+    expect(mapping.category).toBe('Category')
+  })
+
+  it('leaves category undefined when no Category-like column exists', () => {
+    const headers = ['Date', 'Description', 'Amount', 'Running Bal.']
+    const mapping = detectFormat(headers, [])
+    expect(mapping.category).toBeUndefined()
+  })
+
   it('throws when no date column found', () => {
     const headers = ['Foo', 'Bar', 'Amount']
     expect(() => detectFormat(headers, [])).toThrow('date column')
@@ -204,5 +216,32 @@ describe('parseTransactions', () => {
     const { transactions: txns } = parseTransactions('test.csv', rows, mapping)
     expect(txns[0].amount).toBe(25)
     expect(txns[0].type).toBe('credit')
+  })
+
+  it('captures a bank-provided category column onto each transaction', () => {
+    const rows = [
+      { 'Transaction Date': '01/15/2024', Description: 'WHOLEFDS #10', Category: 'Food & Drink', Amount: '42.99' },
+    ]
+    const mapping = detectFormat(['Transaction Date', 'Description', 'Category', 'Amount'], rows)
+    const { transactions: txns } = parseTransactions('chase.csv', rows, mapping)
+    expect(txns[0].bankCategory).toBe('Food & Drink')
+  })
+
+  it('omits bankCategory when the CSV has no Category column', () => {
+    const rows = [
+      { Date: '2024-01-01', Description: 'Rent', Amount: '1500.00' },
+    ]
+    const mapping = detectFormat(['Date', 'Description', 'Amount'], rows)
+    const { transactions: txns } = parseTransactions('test.csv', rows, mapping)
+    expect(txns[0].bankCategory).toBeUndefined()
+  })
+
+  it('omits bankCategory when the row leaves it blank', () => {
+    const rows = [
+      { Date: '2024-01-01', Description: 'Rent', Category: '', Amount: '1500.00' },
+    ]
+    const mapping = detectFormat(['Date', 'Description', 'Category', 'Amount'], rows)
+    const { transactions: txns } = parseTransactions('test.csv', rows, mapping)
+    expect(txns[0].bankCategory).toBeUndefined()
   })
 })

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -12,6 +12,8 @@ export interface ColumnMapping {
   credit?: string
   /** Optional transaction type column */
   type?: string
+  /** Optional bank-provided category column (e.g. Chase's or Monzo's "Category") */
+  category?: string
   /** If true, positive in `amount` means credit (income). Default: false (positive = debit) */
   positiveIsCredit?: boolean
   /** Detected slash-date order for this file. 'dmy' = DD/MM/YYYY, 'mdy' = MM/DD/YYYY (default) */
@@ -38,6 +40,9 @@ const DEBIT_PATTERNS = [
 const CREDIT_PATTERNS = [
   /^credit$/i, /^deposit$/i, /^credit.?amount$/i, /^deposits?$/i,
   /^money.?in$/i, /paid\s*in/i,
+]
+const CATEGORY_PATTERNS = [
+  /^category$/i, /^transaction.?category$/i, /^spending.?category$/i,
 ]
 
 function matchesAny(col: string, patterns: RegExp[]): boolean {
@@ -74,6 +79,7 @@ export function detectFormat(
   const amountCol = headers.find((h) => matchesAny(h, AMOUNT_PATTERNS))
   const debitCol = headers.find((h) => matchesAny(h, DEBIT_PATTERNS))
   const creditCol = headers.find((h) => matchesAny(h, CREDIT_PATTERNS))
+  const categoryCol = headers.find((h) => matchesAny(h, CATEGORY_PATTERNS))
 
   if (!dateCol) throw new Error(`Could not detect date column. Headers: ${headers.join(', ')}`)
   if (!descCol) throw new Error(`Could not detect description column. Headers: ${headers.join(', ')}`)
@@ -117,6 +123,7 @@ export function detectFormat(
   const dateOrder = detectDateOrder(sampleDates)
 
   const mapping: ColumnMapping = { date: dateCol, description: descCol, dateOrder }
+  if (categoryCol) mapping.category = categoryCol
   // Prefer explicit debit/credit split over a single signed amount column —
   // the split is unambiguous and avoids sign-convention guessing.
   if (debitCol || creditCol) {
@@ -241,6 +248,8 @@ export function parseTransactions(
       continue
     }
 
+    const bankCategory = mapping.category ? (row[mapping.category] ?? '').trim() : ''
+
     transactions.push({
       id: `tx-${++txCounter}`,
       date,
@@ -250,6 +259,7 @@ export function parseTransactions(
       category: type === 'credit' ? 'Income' : 'Other',
       subcategory: '',
       sourceFile,
+      ...(bankCategory ? { bankCategory } : {}),
     })
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,14 @@ export interface Transaction {
   category: string
   subcategory: string
   sourceFile: string
+  /** Bank-provided category label, when the source CSV carries one (e.g. Chase's or
+   *  Monzo's "Category" column) — raw bank vocabulary, not yet mapped to our taxonomy.
+   *  See lib/bankCategory.ts. */
+  bankCategory?: string
+  /** Set when this transaction's category/subcategory was assigned by the bank-category
+   *  harvester (lib/bankCategory.ts) rather than the merchant dictionary, cache, or
+   *  Claude — those layers don't tag a source yet. */
+  source?: 'bank'
 }
 
 /** A CSV file that has been loaded and parsed into raw rows */


### PR DESCRIPTION
## Summary

Implements classification PR-5 from `docs/classification-improvement-fable.md` §2.D + §4 "PR-5" — harvesting bank-provided category columns (Chase's, Monzo's `Category`) as a free, key-free classification layer, instead of parsing and discarding them.

- `lib/parser.ts` — `detectFormat` now detects a `Category`-like column and maps it; `parseTransactions` captures it onto `Transaction.bankCategory` (only when non-empty).
- `lib/categoryAliases.ts` (new) — the fuzzy category-vocabulary alias table extracted out of `categorize.ts` (so it has no `@anthropic-ai/sdk` import and can be imported eagerly), plus a handful of new entries for Chase's vocabulary (`Home`, `Bills & Utilities`, `Health & Wellness`, `Interest`). `Charity`/`Tax` are deliberately left unmapped — no home in the current taxonomy (§1.4d, out of scope).
- `lib/bankCategory.ts` (new) — `classifyByBankCategory` translates a raw bank category through the shared alias table; returns `null` (not a guess) when unrecognized.
- `hooks/useCategorization.ts` — wires the harvester in as a fallback layer in `handleFiles`: only consulted when `classifyByMerchant` misses, tags the result `source: 'bank'`.
- `lib/evaluate.ts` + `scripts/generate-golden-corpus.ts` + `sample-data/labeled/*` — golden corpus and eval harness extended to carry/measure the bank-category layer.

## Acceptance criteria

- ✅ **monzo-uk.csv rows whose merchant is unknown to the dictionary but carry `Category: Groceries` classify as Groceries with `source: 'bank'`.** Covered directly by `src/hooks/useCategorization.test.ts` ("harvests bank-provided categories for merchants unknown to the dictionary"), which exercises the real fixture — bare `"Amazon"` (no `.COM`/`MKTP` suffix, unknown to `merchantLookup.ts`) carries Monzo's own `Category: Shopping` and is classified `Shopping` / `source: 'bank'`; a known merchant (Tesco) is confirmed to *not* get a bank source tag. (The literal `Groceries` example from the spec text isn't present as an unmapped row in the current fixture — PR-2 already covers every Groceries merchant in `monzo-uk.csv` via the dictionary — so `src/lib/bankCategory.test.ts` and `src/lib/categoryAliases.test.ts` cover the `Groceries` alias path directly at the unit level.)
- ✅ **Combined fixture coverage (with the normalizer PR) ≥ 93%.** Measured 97.81% on the 1003 existing-fixture rows (981/1003, Layer 0+1+4 combined) and 98.35% on the full corpus (1311/1333) — both floors raised in `evaluate.test.ts` accordingly (`FIXTURE_COMBINED_COVERAGE_FLOOR = 0.977`, `CORPUS_COMBINED_COVERAGE_FLOOR = 0.982`).

## Test plan

- [x] `npm run lint`
- [x] `npm run build` (confirms the bank-category harvester stays out of the lazy `@anthropic-ai/sdk` chunk — `categorize-*.js` chunk size unchanged)
- [x] `npm test` (446 tests passing, including new coverage in `parser.test.ts`, `bankCategory.test.ts`, `categoryAliases.test.ts`, `useCategorization.test.ts`, `evaluate.test.ts`)