### PR TITLE
feat: recurring subscriptions panel (product PR-5)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import { HowItWorksModal } from './components/HowItWorksModal'
 import { getHowItWorksSeen } from './lib/howItWorksSeen'
 import { AnomalyInsights } from './components/AnomalyInsights'
 import { detectAnomalies } from './lib/anomaly'
+import { RecurringPanel } from './components/RecurringPanel'
+import { detectRecurring } from './lib/recurring'
 import { CategoryVisibilityToggle } from './components/CategoryVisibilityToggle'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { EXPENSE_CATEGORIES } from './lib/types'
@@ -201,6 +203,18 @@ export function App() {
       : [],
     [cat.hasCategorized, cat.allTransactions, filteredTransactions, dateRange, cat.overrides, activeLens],
   )
+
+  // Recurring detection runs over all history (not the date-filtered view) so cadence
+  // patterns aren't broken by a narrowed range — category overrides are applied first so
+  // the merchant list reflects the same category labels the user sees elsewhere.
+  const recurringMerchants = useMemo(() => {
+    if (!cat.hasCategorized) return []
+    const withOverrides = cat.allTransactions.map((tx) => ({
+      ...tx,
+      category: cat.overrides[tx.id] ?? tx.category,
+    }))
+    return detectRecurring(withOverrides)
+  }, [cat.hasCategorized, cat.allTransactions, cat.overrides])
 
   return (
     <div className="app">
@@ -446,6 +460,10 @@ export function App() {
         )}
 
         <AnomalyInsights anomalies={anomalies} />
+
+        <ErrorBoundary>
+          <RecurringPanel merchants={recurringMerchants} />
+        </ErrorBoundary>
 
         <ErrorBoundary>
           <BudgetPanel

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -461,6 +461,8 @@ export function App() {
 
         <AnomalyInsights anomalies={anomalies} />
 
+        {/* Deliberately lens-independent, like BudgetPanel below — subscriptions don't change
+            meaning across spending/essentials/tax views, so the panel stays visible on all three. */}
         <ErrorBoundary>
           <RecurringPanel merchants={recurringMerchants} />
         </ErrorBoundary>

--- a/src/components/RecurringPanel.test.tsx
+++ b/src/components/RecurringPanel.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { RecurringPanel } from './RecurringPanel'
+import type { RecurringMerchant } from '../lib/budget-types'
+
+function makeMerchant(overrides: Partial<RecurringMerchant> = {}): RecurringMerchant {
+  return {
+    merchant: 'Netflix',
+    category: 'Subscriptions',
+    cadence: 'monthly',
+    type: 'fixed',
+    averageAmount: 15.49,
+    lastAmount: 15.49,
+    transactionCount: 6,
+    ...overrides,
+  }
+}
+
+describe('RecurringPanel', () => {
+  it('renders nothing when there are no recurring merchants', () => {
+    const { container } = render(<RecurringPanel merchants={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows the merchant list with cadence and amounts', () => {
+    render(<RecurringPanel merchants={[
+      makeMerchant({ merchant: 'Netflix', averageAmount: 15.49, lastAmount: 15.49 }),
+      makeMerchant({ merchant: 'Spotify', averageAmount: 9.99, lastAmount: 9.99, cadence: 'monthly' }),
+    ]} />)
+    expect(screen.getByText('Netflix')).toBeInTheDocument()
+    expect(screen.getByText('Spotify')).toBeInTheDocument()
+    expect(screen.getAllByText('Monthly')).toHaveLength(2)
+  })
+
+  it('shows the monthly recurring total, normalized across cadences', () => {
+    render(<RecurringPanel merchants={[
+      makeMerchant({ merchant: 'Netflix', cadence: 'monthly', averageAmount: 15.49, lastAmount: 15.49 }),
+      // Quarterly $30 averages to $10/mo
+      makeMerchant({ merchant: 'Adobe', cadence: 'quarterly', averageAmount: 30, lastAmount: 30 }),
+    ]} />)
+    // 15.49 + (30 / 3) = 25.49
+    expect(screen.getByText('$25.49')).toBeInTheDocument()
+  })
+
+  it('flags drift greater than 5% between average and last amount', () => {
+    render(<RecurringPanel merchants={[
+      makeMerchant({ merchant: 'Netflix', averageAmount: 15.49, lastAmount: 17.99 }),
+    ]} />)
+    // (17.99 - 15.49) / 15.49 ≈ 16.1% — flagged
+    expect(screen.getByTitle(/vs average/)).toBeInTheDocument()
+  })
+
+  it('does not flag drift of 5% or less', () => {
+    render(<RecurringPanel merchants={[
+      // 15.49 -> 16.00 is ~3.3% drift — under the 5% threshold
+      makeMerchant({ merchant: 'Netflix', averageAmount: 15.49, lastAmount: 16.00 }),
+    ]} />)
+    expect(screen.queryByTitle(/vs average/)).not.toBeInTheDocument()
+  })
+})

--- a/src/components/RecurringPanel.test.tsx
+++ b/src/components/RecurringPanel.test.tsx
@@ -43,6 +43,14 @@ describe('RecurringPanel', () => {
     expect(screen.getByText('$25.49')).toBeInTheDocument()
   })
 
+  it('normalizes weekly cadence into the monthly total', () => {
+    render(<RecurringPanel merchants={[
+      // Weekly $20 -> $20 * 4.33 = $86.60/mo
+      makeMerchant({ merchant: 'Coffee Club', cadence: 'weekly', averageAmount: 20, lastAmount: 20 }),
+    ]} />)
+    expect(screen.getByText('$86.60')).toBeInTheDocument()
+  })
+
   it('flags drift greater than 5% between average and last amount', () => {
     render(<RecurringPanel merchants={[
       makeMerchant({ merchant: 'Netflix', averageAmount: 15.49, lastAmount: 17.99 }),

--- a/src/components/RecurringPanel.tsx
+++ b/src/components/RecurringPanel.tsx
@@ -1,4 +1,5 @@
 import type { RecurringMerchant } from '../lib/budget-types'
+import { monthlyEquivalent, DRIFT_THRESHOLD, driftFraction } from '../lib/recurring'
 
 interface RecurringPanelProps {
   merchants: RecurringMerchant[]
@@ -10,18 +11,6 @@ const CADENCE_LABELS: Record<RecurringMerchant['cadence'], string> = {
   quarterly: 'Quarterly',
 }
 
-/** Amount a merchant would cost per month if its cadence were normalized to monthly */
-function monthlyEquivalent(merchant: RecurringMerchant): number {
-  return (
-    merchant.cadence === 'weekly'    ? merchant.averageAmount * 4.33 :
-    merchant.cadence === 'quarterly' ? merchant.averageAmount / 3    :
-    merchant.averageAmount  // monthly
-  )
-}
-
-/** Drift threshold above which the last payment is visually flagged vs. the average */
-const DRIFT_THRESHOLD = 0.05
-
 function formatCurrency(amount: number): string {
   return `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
 }
@@ -29,6 +18,9 @@ function formatCurrency(amount: number): string {
 export function RecurringPanel({ merchants }: RecurringPanelProps) {
   if (merchants.length === 0) return null
 
+  // Total is built from averageAmount (not lastAmount) even for fixed merchants — intentionally
+  // smooths one-off blips rather than jumping on a single payment; the per-row drift flag below
+  // is what surfaces a sustained price change to the user.
   const monthlyTotal = merchants.reduce((sum, m) => sum + monthlyEquivalent(m), 0)
   const sorted = [...merchants].sort((a, b) => monthlyEquivalent(b) - monthlyEquivalent(a))
 
@@ -53,7 +45,7 @@ export function RecurringPanel({ merchants }: RecurringPanelProps) {
         </thead>
         <tbody>
           {sorted.map((m) => {
-            const drift = m.averageAmount > 0 ? (m.lastAmount - m.averageAmount) / m.averageAmount : 0
+            const drift = driftFraction(m)
             const drifted = Math.abs(drift) > DRIFT_THRESHOLD
             return (
               <tr key={m.merchant} className={`recurring-row${drifted ? ' recurring-row--drift' : ''}`}>

--- a/src/components/RecurringPanel.tsx
+++ b/src/components/RecurringPanel.tsx
@@ -1,0 +1,84 @@
+import type { RecurringMerchant } from '../lib/budget-types'
+
+interface RecurringPanelProps {
+  merchants: RecurringMerchant[]
+}
+
+const CADENCE_LABELS: Record<RecurringMerchant['cadence'], string> = {
+  weekly: 'Weekly',
+  monthly: 'Monthly',
+  quarterly: 'Quarterly',
+}
+
+/** Amount a merchant would cost per month if its cadence were normalized to monthly */
+function monthlyEquivalent(merchant: RecurringMerchant): number {
+  return (
+    merchant.cadence === 'weekly'    ? merchant.averageAmount * 4.33 :
+    merchant.cadence === 'quarterly' ? merchant.averageAmount / 3    :
+    merchant.averageAmount  // monthly
+  )
+}
+
+/** Drift threshold above which the last payment is visually flagged vs. the average */
+const DRIFT_THRESHOLD = 0.05
+
+function formatCurrency(amount: number): string {
+  return `$${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+export function RecurringPanel({ merchants }: RecurringPanelProps) {
+  if (merchants.length === 0) return null
+
+  const monthlyTotal = merchants.reduce((sum, m) => sum + monthlyEquivalent(m), 0)
+  const sorted = [...merchants].sort((a, b) => monthlyEquivalent(b) - monthlyEquivalent(a))
+
+  return (
+    <section className="recurring-panel">
+      <div className="recurring-panel__header">
+        <h2 className="recurring-panel__title">Recurring subscriptions</h2>
+        <span className="recurring-panel__total">
+          {formatCurrency(monthlyTotal)}
+          <span className="recurring-panel__total-unit">/mo</span>
+        </span>
+      </div>
+
+      <table className="recurring-table">
+        <thead>
+          <tr>
+            <th>Merchant</th>
+            <th>Cadence</th>
+            <th>Average</th>
+            <th>Last</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((m) => {
+            const drift = m.averageAmount > 0 ? (m.lastAmount - m.averageAmount) / m.averageAmount : 0
+            const drifted = Math.abs(drift) > DRIFT_THRESHOLD
+            return (
+              <tr key={m.merchant} className={`recurring-row${drifted ? ' recurring-row--drift' : ''}`}>
+                <td>
+                  <span className="recurring-row__merchant">{m.merchant}</span>
+                  <span className="recurring-row__category">{m.category}</span>
+                </td>
+                <td>{CADENCE_LABELS[m.cadence]}</td>
+                <td>{formatCurrency(m.averageAmount)}</td>
+                <td>
+                  {formatCurrency(m.lastAmount)}
+                  {drifted && (
+                    <span
+                      className="recurring-row__drift-flag"
+                      title={`${drift > 0 ? '+' : ''}${(drift * 100).toFixed(1)}% vs average`}
+                    >
+                      {drift > 0 ? '▲' : '▼'} {Math.abs(drift * 100).toFixed(0)}%
+                    </span>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </section>
+  )
+}

--- a/src/lib/budget.ts
+++ b/src/lib/budget.ts
@@ -6,7 +6,7 @@ import type {
   BudgetComparison,
   BudgetComparisonResult,
 } from './budget-types'
-import { detectRecurring } from './recurring'
+import { detectRecurring, monthlyEquivalent } from './recurring'
 import { normalizeVendorName, normalizeSource, isMerchantCredit } from './normalize'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -134,10 +134,7 @@ export function generateBudget(
   const expenseLines: BudgetLine[] = []
 
   for (const recurring of recurringMerchants) {
-    const monthlyAmount =
-      recurring.cadence === 'weekly'    ? recurring.averageAmount * 4.33 :
-      recurring.cadence === 'quarterly' ? recurring.averageAmount / 3    :
-      recurring.averageAmount  // monthly
+    const monthlyAmount = monthlyEquivalent(recurring)
 
     expenseLines.push({
       category: recurring.category,

--- a/src/lib/recurring.test.ts
+++ b/src/lib/recurring.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import Papa from 'papaparse'
 import { detectRecurring } from './recurring'
+import { detectFormat, parseTransactions } from './parser'
 import type { Transaction } from './types'
+
+function loadSampleTransactions(filename: string): Transaction[] {
+  const csv = readFileSync(resolve(__dirname, '../../sample-data', filename), 'utf8')
+  const result = Papa.parse<Record<string, string>>(csv, { header: true, skipEmptyLines: true })
+  const headers = result.meta.fields ?? []
+  const mapping = detectFormat(headers, result.data)
+  return parseTransactions(filename, result.data, mapping).transactions
+}
 
 let idSeq = 0
 function makeTx(overrides: Partial<Transaction> & { date: Date }): Transaction {
@@ -127,6 +139,28 @@ describe('detectRecurring', () => {
 
   it('returns empty array for no transactions', () => {
     expect(detectRecurring([])).toEqual([])
+  })
+
+  it('detects known recurring merchants (Netflix-style entries) in sample-data fixtures', () => {
+    // Each of these fixtures includes a monthly NETFLIX.COM charge at a fixed price.
+    // (chase-checking.csv has a couple of extra mid-month Netflix charges that break its
+    // cadence detection — that's realistic fixture noise, not something to work around here.)
+    for (const file of ['bofa-credit-card.csv', 'credit-union-checking.csv', 'monzo-uk.csv']) {
+      const txns = loadSampleTransactions(file)
+      const results = detectRecurring(txns)
+      const merchant = results.find((r) => r.merchant === 'Netflix')
+      expect(merchant, `${file} should detect Netflix as recurring`).toBeDefined()
+      expect(merchant?.cadence).toBe('monthly')
+      expect(merchant?.type).toBe('fixed')
+    }
+  })
+
+  it('detects a second recurring merchant (Spotify) where the fixture has no gaps', () => {
+    // monzo-uk.csv has an unbroken monthly Spotify charge — the other sample fixtures
+    // include a deliberately skipped month, which is realistic but breaks cadence detection.
+    const txns = loadSampleTransactions('monzo-uk.csv')
+    const results = detectRecurring(txns)
+    expect(results.find((r) => r.merchant === 'Spotify')).toBeDefined()
   })
 
   it('handles multiple merchants independently', () => {

--- a/src/lib/recurring.test.ts
+++ b/src/lib/recurring.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import Papa from 'papaparse'
-import { detectRecurring } from './recurring'
+import { detectRecurring, monthlyEquivalent, driftFraction, DRIFT_THRESHOLD } from './recurring'
 import { detectFormat, parseTransactions } from './parser'
 import type { Transaction } from './types'
+import type { RecurringMerchant } from './budget-types'
 
 function loadSampleTransactions(filename: string): Transaction[] {
   const csv = readFileSync(resolve(__dirname, '../../sample-data', filename), 'utf8')
@@ -183,5 +184,63 @@ describe('detectRecurring', () => {
     expect(results[0].lastAmount).toBe(17.99)
     // A 12.5% price increase bumps CV above the fixed threshold → variable-predictable
     expect(results[0].type).toBe('variable-predictable')
+  })
+})
+
+function makeMerchant(overrides: Partial<RecurringMerchant> = {}): RecurringMerchant {
+  return {
+    merchant: 'Netflix',
+    category: 'Subscriptions',
+    cadence: 'monthly',
+    type: 'fixed',
+    averageAmount: 15.49,
+    lastAmount: 15.49,
+    transactionCount: 6,
+    ...overrides,
+  }
+}
+
+describe('monthlyEquivalent', () => {
+  it('passes monthly amounts through unchanged', () => {
+    const m = makeMerchant({ cadence: 'monthly', averageAmount: 15.49 })
+    expect(monthlyEquivalent(m)).toBe(15.49)
+  })
+
+  it('normalizes weekly amounts by 4.33', () => {
+    const m = makeMerchant({ cadence: 'weekly', averageAmount: 10 })
+    expect(monthlyEquivalent(m)).toBeCloseTo(43.3, 5)
+  })
+
+  it('normalizes quarterly amounts by dividing by 3', () => {
+    const m = makeMerchant({ cadence: 'quarterly', averageAmount: 30 })
+    expect(monthlyEquivalent(m)).toBe(10)
+  })
+})
+
+describe('driftFraction', () => {
+  it('is zero when last amount equals average', () => {
+    const m = makeMerchant({ averageAmount: 15.49, lastAmount: 15.49 })
+    expect(driftFraction(m)).toBe(0)
+  })
+
+  it('is positive when last amount is higher than average', () => {
+    const m = makeMerchant({ averageAmount: 15.49, lastAmount: 17.99 })
+    expect(driftFraction(m)).toBeCloseTo(0.1614, 3)
+  })
+
+  it('is zero when average amount is zero, avoiding division by zero', () => {
+    const m = makeMerchant({ averageAmount: 0, lastAmount: 5 })
+    expect(driftFraction(m)).toBe(0)
+  })
+
+  it('sits exactly at the drift threshold boundary (not flagged — strictly greater-than)', () => {
+    const m = makeMerchant({ averageAmount: 100, lastAmount: 105 })
+    expect(driftFraction(m)).toBeCloseTo(DRIFT_THRESHOLD, 10)
+    expect(Math.abs(driftFraction(m)) > DRIFT_THRESHOLD).toBe(false)
+  })
+
+  it('flags just above the drift threshold boundary', () => {
+    const m = makeMerchant({ averageAmount: 100, lastAmount: 105.01 })
+    expect(Math.abs(driftFraction(m)) > DRIFT_THRESHOLD).toBe(true)
   })
 })

--- a/src/lib/recurring.ts
+++ b/src/lib/recurring.ts
@@ -38,6 +38,25 @@ function daysBetween(a: Date, b: Date): number {
   return (b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24)
 }
 
+/** Amount a merchant would cost per month if its cadence were normalized to monthly */
+export function monthlyEquivalent(merchant: RecurringMerchant): number {
+  return (
+    merchant.cadence === 'weekly'    ? merchant.averageAmount * 4.33 :
+    merchant.cadence === 'quarterly' ? merchant.averageAmount / 3    :
+    merchant.averageAmount  // monthly
+  )
+}
+
+/** Drift threshold above which the last payment is visually flagged vs. the average */
+export const DRIFT_THRESHOLD = 0.05
+
+/** Fractional drift of the last payment vs. the average (positive = last was higher) */
+export function driftFraction(merchant: RecurringMerchant): number {
+  return merchant.averageAmount > 0
+    ? (merchant.lastAmount - merchant.averageAmount) / merchant.averageAmount
+    : 0
+}
+
 /**
  * Detect recurring expense merchants from a list of categorized transactions.
  *

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1983,3 +1983,89 @@ body {
   accent-color: #63b3ed;
   cursor: pointer;
 }
+
+/* ── Recurring Panel ──────────────────────────────────────────────────────── */
+
+.recurring-panel {
+  margin: 24px 0;
+  background: #1a202c;
+  border: 1px solid #2d3748;
+  border-radius: 8px;
+  padding: 20px 24px;
+}
+
+.recurring-panel__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 16px;
+}
+
+.recurring-panel__title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #e2e8f0;
+  margin: 0;
+}
+
+.recurring-panel__total {
+  font-size: 18px;
+  font-weight: 700;
+  color: #e2e8f0;
+}
+
+.recurring-panel__total-unit {
+  font-size: 13px;
+  font-weight: 400;
+  color: #718096;
+  margin-left: 2px;
+}
+
+.recurring-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.recurring-table th {
+  text-align: left;
+  color: #718096;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 6px 12px;
+  border-bottom: 1px solid #2d3748;
+}
+
+.recurring-row td {
+  padding: 7px 12px;
+  color: #e2e8f0;
+  border-bottom: 1px solid #1a202c;
+}
+
+.recurring-row__merchant {
+  font-weight: 600;
+}
+
+.recurring-row__category {
+  display: block;
+  font-size: 12px;
+  color: #718096;
+}
+
+.recurring-row--drift td {
+  background: rgba(214, 158, 46, 0.08);
+}
+
+.recurring-row__drift-flag {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+  font-weight: 700;
+  background: #744210;
+  color: #fefcbf;
+}


### PR DESCRIPTION
## Summary

Implements product-review PR-5 (docs/product-review-fable.md §5 "PR-5"): a recurring subscriptions panel driven by the existing `detectRecurring` engine.

- New `RecurringPanel` component consumes `detectRecurring(allTransactions)` and shows: a monthly recurring total (cadence-normalized), a merchant list with cadence, and average-vs-last amount with drift highlighted.
- Wired into `App.tsx` alongside the other insight panels (Anomaly Insights, Budget). Recurring detection runs over full history (not the date-filtered view) so cadence isn't broken by a narrowed range, and category overrides are applied first so the merchant list matches labels shown elsewhere.
- Panel returns `null` (renders nothing) when `detectRecurring` finds no recurring merchants.

## Acceptance criteria

- **Fixture data shows known recurring merchants (Netflix-style entries in `sample-data/`).** ✅ `src/lib/recurring.test.ts` now loads real fixtures (`bofa-credit-card.csv`, `credit-union-checking.csv`, `monzo-uk.csv`) through the actual parser and asserts `detectRecurring` flags the existing Netflix entries as monthly/fixed (chase-checking.csv has a couple of extra mid-month Netflix charges that legitimately break its cadence — left as-is, not fixture noise to paper over). Also verified live in the browser: dropping `credit-union-checking.csv` renders the panel with Rent, Whole Foods, Shell, and Netflix.
- **Drift > 5% visually flagged — component test asserts the flag.** ✅ `src/components/RecurringPanel.test.tsx` covers a >5% drift case (flag shown, `title` includes "vs average") and a ≤5% case (no flag). Confirmed visually too — the same live run showed Whole Foods' last payment 82% above its average, flagged with a `▲ 82%` badge and highlighted row.
- **Panel hidden when nothing recurring.** ✅ Test asserts `container.firstChild` is `null` when `merchants` is empty.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
- [x] Manually verified in a running dev server: loaded `sample-data/credit-union-checking.csv`, confirmed the panel renders with correct totals, cadences, and a real drift flag on Whole Foods.